### PR TITLE
DSL and SwaggerModule

### DIFF
--- a/src/Nancy.Swagger/Modules/SwaggerModule.cs
+++ b/src/Nancy.Swagger/Modules/SwaggerModule.cs
@@ -1,0 +1,75 @@
+﻿namespace Nancy.Swagger.Modules
+{
+    using System;
+    using System.Linq;
+
+    using Nancy.Routing;
+    using Nancy.Swagger.ApiDeclaration;
+    using Nancy.Swagger.ResourceListing;
+
+    using Newtonsoft.Json;
+
+    public class SwaggerModule : NancyModule
+    {
+        public SwaggerModule(IRouteCacheProvider routeCacheProvider)
+            : base("api-docs") // TODO: Make the base path configurable
+        {
+            this.Get["/"] = _ =>
+            {
+                var metadata = routeCacheProvider
+                    .GetCache()
+                    .RetrieveMetadata<SwaggerRouteData>()
+                    .OfType<SwaggerRouteData>(); // filter nulls
+
+                var resourceListing = new ResourceListing
+                {
+                    Apis = metadata
+                        .Select(d => d.ResourcePath)
+                        .Distinct()
+                        .Select(path => new Resource { Path = path })
+                };
+
+                return JsonConvert.SerializeObject(resourceListing);
+            };
+
+            this.Get["/{resourcePath*}"] = _ =>
+            {
+                string path = "/" + _.resourcePath;
+                var metadata = routeCacheProvider
+                    .GetCache()
+                    .RetrieveMetadata<SwaggerRouteData>()
+                    .OfType<SwaggerRouteData>() // filter nulls
+                    .Where(d => d.ResourcePath == path);
+
+                var apiDeclaration = new ApiDeclaration
+                {
+                    BasePath = new Uri("/", UriKind.Relative),
+                    Apis =
+                        metadata.GroupBy(d => d.ApiPath).Select(
+                            group =>
+                            new Api
+                            {
+                                Path = group.Key,
+                                Operations =
+                                    group.Select(
+                                        desc =>
+                                        new Operation
+                                        {
+                                            Nickname = desc.OperationNickname,
+                                            Summary = desc.OperationSummary,
+                                            Method = desc.OperationMethod,
+                                            Notes = desc.OperationNotes,
+                                            Parameters = desc.OperationParameters,
+                                            ResponseMessages = desc.OperationResponseMessages,
+                                            Produces = desc.OperationProduces,
+                                            Consumes = desc.OperationConsumes,
+                                            Type = desc.OperationType
+                                        })
+                            })
+                };
+
+                return JsonConvert.SerializeObject(apiDeclaration);
+            };
+        }
+    }
+}

--- a/src/Nancy.Swagger/Nancy.Swagger.csproj
+++ b/src/Nancy.Swagger/Nancy.Swagger.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Nancy">
-      <HintPath>..\..\packages\Nancy.0.23-Pre1363\lib\net40\Nancy.dll</HintPath>
+      <HintPath>..\..\packages\Nancy.0.23.0\lib\net40\Nancy.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -57,6 +57,7 @@
     <Compile Include="ApiDeclaration\Parameter.cs" />
     <Compile Include="ApiDeclaration\ParameterType.cs" />
     <Compile Include="ApiDeclaration\ResponseMessage.cs" />
+    <Compile Include="Modules\SwaggerModule.cs" />
     <Compile Include="Properties\Annotations.cs" />
     <Compile Include="ApiDeclaration\ApiDeclaration.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -75,9 +76,14 @@
     <Compile Include="ResourceListing\TokenEndpoint.cs" />
     <Compile Include="ResourceListing\TokenRequestEndpoint.cs" />
     <Compile Include="Primitive.cs" />
+    <Compile Include="SwaggerExtensions.cs" />
+    <Compile Include="SwaggerRouteData.cs" />
+    <Compile Include="SwaggerRouteDataBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Nancy.Swagger/SwaggerExtensions.cs
+++ b/src/Nancy.Swagger/SwaggerExtensions.cs
@@ -1,0 +1,46 @@
+﻿namespace Nancy.Swagger
+{
+    using System;
+
+    using Nancy.Routing;
+    using Nancy.Swagger.ApiDeclaration;
+
+    public static class SwaggerExtensions
+    {
+        /// <summary>
+        /// Returns an instance of <see cref="SwaggerRouteData"/> representing this route.
+        /// </summary>
+        /// <param name="desc">The <see cref="RouteDescription"/>.</param>
+        /// <param name="action">An <see cref="Action{SwaggerRouteDataBuilder}"/> for building the <see cref="SwaggerRouteData"/>.</param>
+        /// <returns>An instance of <see cref="SwaggerRouteData"/> constructed using <paramref name="desc"/> and by invoking <paramref name="action"/>.</returns>
+        public static SwaggerRouteData AsSwagger(this RouteDescription desc, Action<SwaggerRouteDataBuilder> action)
+        {
+            var builder = new SwaggerRouteDataBuilder(desc.Name, Convert(desc.Method), desc.Path);
+
+            action.Invoke(builder);
+
+            return builder.Data;
+        }
+
+        private static HttpMethod Convert(string method)
+        {
+            switch (method)
+            {
+                case "DELETE":
+                    return HttpMethod.Delete;
+                case "GET":
+                    return HttpMethod.Get;
+                case "OPTIONS":
+                    return HttpMethod.Options;
+                case "PATCH":
+                    return HttpMethod.Patch;
+                case "POST":
+                    return HttpMethod.Post;
+                case "PUT":
+                    return HttpMethod.Put;
+                default:
+                    throw new NotSupportedException(string.Format("HTTP method '{0}' is not supported.", method));
+            }
+        }
+    }
+}

--- a/src/Nancy.Swagger/SwaggerRouteData.cs
+++ b/src/Nancy.Swagger/SwaggerRouteData.cs
@@ -1,0 +1,45 @@
+﻿namespace Nancy.Swagger
+{
+    using System.Collections.Generic;
+
+    using Nancy.Swagger.ApiDeclaration;
+
+    /// <summary>
+    /// Holds all the Swagger metadata pertaining to a specific route.
+    /// </summary>
+    public class SwaggerRouteData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SwaggerRouteData"/> class.
+        /// </summary>
+        public SwaggerRouteData()
+        {
+            this.OperationParameters = new List<Parameter>();
+            this.OperationResponseMessages = new List<ResponseMessage>();
+            this.OperationProduces = new List<string>();
+            this.OperationConsumes = new List<string>();
+        }
+
+        public string ResourcePath { get; set; }
+
+        public string ApiPath { get; set; }
+
+        public string OperationNickname { get; set; }
+
+        public string OperationSummary { get; set; }
+
+        public HttpMethod OperationMethod { get; set; }
+
+        public string OperationNotes { get; set; }
+
+        public IList<Parameter> OperationParameters { get; set; }
+
+        public IList<ResponseMessage> OperationResponseMessages { get; set; }
+
+        public IList<string> OperationProduces { get; set; }
+
+        public IList<string> OperationConsumes { get; set; }
+
+        public string OperationType { get; set; }
+    }
+}

--- a/src/Nancy.Swagger/SwaggerRouteDataBuilder.cs
+++ b/src/Nancy.Swagger/SwaggerRouteDataBuilder.cs
@@ -1,0 +1,126 @@
+﻿namespace Nancy.Swagger
+{
+    using System;
+
+    using Nancy.Swagger.ApiDeclaration;
+
+    /// <summary>
+    /// Helper class for configuring an instance of <see cref="SwaggerRouteData"/>.
+    /// </summary>
+    public class SwaggerRouteDataBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SwaggerRouteDataBuilder"/> class.
+        /// </summary>
+        /// <param name="operationNickName">The nickname for the operation.</param>
+        /// <param name="method">The method for the route.</param>
+        /// <param name="apiPath">The path for the API.</param>
+        public SwaggerRouteDataBuilder(string operationNickName, HttpMethod method, string apiPath)
+        {
+            this.Data = new SwaggerRouteData
+                {
+                    OperationNickname = operationNickName,
+                    OperationMethod = method,
+                    ApiPath = apiPath
+                };
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SwaggerRouteData"/> instance.
+        /// </summary>
+        public SwaggerRouteData Data { get; set; }
+
+        /// <summary>
+        /// Specify the path for the resource.
+        /// </summary>
+        /// <param name="resourcePath">The resource path.</param>
+        /// <returns>The <see cref="SwaggerRouteDataBuilder"/> instance.</returns>
+        public SwaggerRouteDataBuilder ResourcePath(string resourcePath)
+        {
+            this.Data.ResourcePath = resourcePath;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Specify the summary for the operation.
+        /// </summary>
+        /// <param name="summary">The operation summary.</param>
+        /// <returns>The <see cref="SwaggerRouteDataBuilder"/> instance.</returns>
+        public SwaggerRouteDataBuilder Summary(string summary)
+        {
+            this.Data.OperationSummary = summary;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Specify the notes for the operation.
+        /// </summary>
+        /// <param name="notes">The operation notes.</param>
+        /// <returns>The <see cref="SwaggerRouteDataBuilder"/> instance.</returns>
+        public SwaggerRouteDataBuilder Notes(string notes)
+        {
+            this.Data.OperationNotes = notes;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Specify a query parameter for the operation.
+        /// </summary>
+        /// <param name="name">The name of the parameter.</param>
+        /// <param name="description">The description of the parameter.</param>
+        /// <param name="required">A <see cref="Boolean"/> value indicating whether the parameter is required. The default is <c>false</c>.</param>
+        /// <param name="allowMultiple">A <see cref="Boolean"/> value indicating whether the parameter is allowed to appear more than once. The default is <c>false</c>.</param>
+        /// <param name="defaultValue">The default value to be used for the field.</param>
+        /// <returns>The <see cref="SwaggerRouteDataBuilder"/> instance.</returns>
+        public SwaggerRouteDataBuilder QueryParam<T>(
+            string name,
+            string description = null,
+            bool required = false,
+            bool allowMultiple = false,
+            T defaultValue = default(T))
+        {
+            var param = new Parameter
+                {
+                    Name = name,
+                    Type = ToSwaggerType(typeof(T)),
+                    ParamType = ParameterType.Query,
+                    Description = description,
+                    Required = required,
+                    AllowMultiple = allowMultiple,
+                    DefaultValue = defaultValue
+                };
+
+            this.Data.OperationParameters.Add(param);
+
+            return this;
+        }
+
+        private static string ToSwaggerType(Type type)
+        {
+            if (type == typeof(int) || type == typeof(long))
+            {
+                return "integer";
+            }
+
+            if (type == typeof(float) || type == typeof(double))
+            {
+                return "number";
+            }
+
+            if (type == typeof(bool))
+            {
+                return "boolean";
+            }
+
+            if (type == typeof(string) || type == typeof(byte) || type == typeof(DateTime))
+            {
+                return "string";
+            }
+
+            throw new NotSupportedException("The specified type could not be converted to a Swagger primitive.");
+        }
+    }
+}

--- a/src/Nancy.Swagger/packages.config
+++ b/src/Nancy.Swagger/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Nancy" version="0.23-Pre1363" targetFramework="net40" />
+  <package id="Nancy" version="0.23.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Here is what I currently have for describing routes and publishing the corresponding Swagger endpoint. I've added a `SwaggerModule` - which picks up metadata from `IRouteCacheProvider`.

To populate the metadata in the first place, there is an `AsSwagger` extension method on `RouteDescription` - which returns a `SwaggerRouteDataBuilder`. The builder gives you access to the DSL I previewed last week on JabbR and exposes an instance of `SwaggerRouteData`.

Assuming a module called `UserModule` with a named route called _GetUsers_, this can be used with a metadata module like this:

``` c#
public class UserMetadataModule : MetadataModule<SwaggerRouteData>
{
    public UserMetadataModule()
    {
        this.Describe["GetUsers"] = desc =>
            {
                return desc.AsSwagger(with =>
                    {
                        with.ResourcePath("/users");
                        with.Summary("Search users");
                        with.Notes("Returns users based on the given search criteria");
                        with.QueryParam<string>("query", "Query to search by");
                        with.QueryParam("page", "Page of results to return", defaultValue: 0);
                        with.QueryParam("pageSize", "Number of results per page", defaultValue: 10);
                    });
            };
    }
}
```

In it's current form the easiest steps to get up and running are:
1. Add a reference to this library.
2. Add a reference to the _Nancy.MetaData_ NuGet (the name of this package [may](https://github.com/NancyFx/Nancy/pull/1555) change in the future),
3. Implement one or more metadata modules as per the example above.

The DSL is incomplete. In particular, you cannot yet describe a model.
