### PR TITLE
Ensure when ParamType equals "body" name also equals "body"

### DIFF
--- a/src/Nancy.Swagger.Annotations/Attributes/SwaggerRouteParamAttribute.cs
+++ b/src/Nancy.Swagger.Annotations/Attributes/SwaggerRouteParamAttribute.cs
@@ -13,7 +13,7 @@ namespace Nancy.Swagger.Annotations.Attributes
         {
         }
 
-        public SwaggerRouteParamAttribute(ParameterType paramType, string name)
+        public SwaggerRouteParamAttribute(ParameterType paramType, string name = null)
             : base(name)
         {
             ParamType = paramType;

--- a/src/Nancy.Swagger/SwaggerExtensions.cs
+++ b/src/Nancy.Swagger/SwaggerExtensions.cs
@@ -93,6 +93,13 @@ namespace Nancy.Swagger
             parameter.Required = parameterData.Required || parameterData.ParameterModel.IsImplicitlyRequired();
             parameter.AllowMultiple = parameterData.AllowMultiple;
             parameter.DefaultValue = parameterData.DefaultValue;
+
+            // Ensure when ParamType equals "body" name also equals "body" 
+            // See https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#524-parameter-object
+            if (parameter.ParamType == ParameterType.Body)
+            {
+                parameter.Name = "body";
+            }
             
             return parameter;
         }

--- a/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_TestModulePath_ReturnsApiDeclaration.approved.txt
+++ b/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_TestModulePath_ReturnsApiDeclaration.approved.txt
@@ -103,6 +103,123 @@
                         
                     ],
                     "$ref":"TestModel"
+                },
+                {
+                    "method":"POST",
+                    "nickname":"/testroutes/models/{id}",
+                    "parameters":[
+                        {
+                            "paramType":"body",
+                            "name":"body",
+                            "required":true,
+                            "allowMultiple":false,
+                            "$ref":"TestModel"
+                        }
+                    ],
+                    "responseMessages":[
+                        
+                    ],
+                    "produces":[
+                        
+                    ],
+                    "consumes":[
+                        
+                    ],
+                    "type":"void"
+                },
+                {
+                    "method":"PUT",
+                    "nickname":"/testroutes/models/{id}",
+                    "parameters":[
+                        {
+                            "paramType":"body",
+                            "name":"body",
+                            "required":false,
+                            "allowMultiple":false,
+                            "$ref":"TestModel"
+                        }
+                    ],
+                    "responseMessages":[
+                        
+                    ],
+                    "produces":[
+                        
+                    ],
+                    "consumes":[
+                        
+                    ],
+                    "type":"void"
+                },
+                {
+                    "method":"PATCH",
+                    "nickname":"/testroutes/models/{id}",
+                    "parameters":[
+                        {
+                            "paramType":"body",
+                            "name":"body",
+                            "required":false,
+                            "allowMultiple":false,
+                            "$ref":"TestModel"
+                        }
+                    ],
+                    "responseMessages":[
+                        
+                    ],
+                    "produces":[
+                        
+                    ],
+                    "consumes":[
+                        
+                    ],
+                    "type":"void"
+                },
+                {
+                    "method":"DELETE",
+                    "nickname":"/testroutes/models/{id}",
+                    "parameters":[
+                        {
+                            "paramType":"path",
+                            "name":"id",
+                            "required":true,
+                            "allowMultiple":false,
+                            "type":"integer",
+                            "format":"int32"
+                        }
+                    ],
+                    "responseMessages":[
+                        
+                    ],
+                    "produces":[
+                        
+                    ],
+                    "consumes":[
+                        
+                    ],
+                    "type":"void"
+                },
+                {
+                    "method":"OPTIONS",
+                    "nickname":"/testroutes/models/{id}",
+                    "parameters":[
+                        {
+                            "paramType":"path",
+                            "name":"id",
+                            "required":true,
+                            "allowMultiple":false,
+                            "type":"integer",
+                            "format":"int32"
+                        }
+                    ],
+                    "responseMessages":[
+                        
+                    ],
+                    "produces":[
+                        
+                    ],
+                    "consumes":[
+                        
+                    ],
+                    "type":"void"
                 }
             ]
         },

--- a/test/Nancy.Swagger.Annotations.Tests/TestRoutesModule.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/TestRoutesModule.cs
@@ -1,4 +1,5 @@
-﻿using Nancy.Swagger.Annotations.Attributes;
+﻿using Nancy.ModelBinding;
+using Nancy.Swagger.Annotations.Attributes;
 using Swagger.ObjectModel.ApiDeclaration;
 using System;
 
@@ -18,16 +19,30 @@ namespace Nancy.Swagger.Annotations.Tests
             Get["/strings/{id}"] = _ => GetStringById(_.id, Request.Query.q);
 
             // Non-primitive response
-            Get["/models"] = _ => GetModels();
+            Get["/models"] = _ => GetModels();            
             Get["/models/{id}"] = _ => GetModel(_.id);
+            Post["/models/{id}"] = _ => PostModel(this.Bind<TestModel>());
+            Put["/models/{id}"] = _ => PutModel(this.Bind<TestModel>());
+            Delete["/models/{id}"] = _ => DeleteModel(_.id);
+            Patch["/models/{id}"] = _ => PatchModel(this.Bind<TestModel>());
+            Options["/models/{id}"] = _ => OptionsModel(_.id);
 
             // Named route
             Get["GetIntegers", "/integers"] = _ => GetIntegers();
-        }
 
+            
+        }
+        
         [SwaggerRoute("GetIntegers")]
         [SwaggerRoute(Response = typeof(int[]))]
         private static dynamic GetIntegers()
+        {
+            throw new NotImplementedException();
+        }
+
+        [SwaggerRoute(HttpMethod.Get, "/models")]
+        [SwaggerRoute(Response = typeof(TestModel[]))]
+        private static dynamic GetModels()
         {
             throw new NotImplementedException();
         }
@@ -41,9 +56,42 @@ namespace Nancy.Swagger.Annotations.Tests
             throw new NotImplementedException();
         }
 
-        [SwaggerRoute(HttpMethod.Get, "/models")]
-        [SwaggerRoute(Response = typeof(TestModel[]))]
-        private static dynamic GetModels()
+        [SwaggerRoute(HttpMethod.Options, "/models/{id}")]        
+        private dynamic OptionsModel(
+            [SwaggerRouteParam(ParameterType.Path, "id")] int id
+        )
+        {
+            throw new NotImplementedException();
+        }
+
+        [SwaggerRoute(HttpMethod.Delete, "/models/{id}")]
+        private dynamic DeleteModel(
+            [SwaggerRouteParam(ParameterType.Path, "id")] int id
+        )
+        {
+            throw new NotImplementedException();
+        }
+
+        [SwaggerRoute(HttpMethod.Patch, "/models/{id}")] 
+        private dynamic PatchModel(
+            [SwaggerRouteParam(ParameterType.Body)] TestModel testModel
+        )
+        {
+            throw new NotImplementedException();
+        }
+
+        [SwaggerRoute(HttpMethod.Put, "/models/{id}")] 
+        private dynamic PutModel(
+            [SwaggerRouteParam(ParameterType.Body)] TestModel testModel
+        )        
+        {
+            throw new NotImplementedException();
+        }
+
+        [SwaggerRoute(HttpMethod.Post, "/models/{id}")]
+        private dynamic PostModel(
+            [SwaggerRouteParam(ParameterType.Body, Required = true)] TestModel testModel
+        )
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Fixes the behaviour described by @jchannon in #26. When ParamType equals "body" name also equals "body".
See https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#524-parameter-object

This commit overrules any name given in the metadata by "body" when ParamType equals "body"
