### PR TITLE
Added SwaggerRouteResponseAttribute

### DIFF
--- a/src/Nancy.Swagger.Annotations/Attributes/SwaggerResponse.cs
+++ b/src/Nancy.Swagger.Annotations/Attributes/SwaggerResponse.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Nancy.Swagger.Annotations.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
+    public class SwaggerResponseAttribute : Attribute
+    {
+        public SwaggerResponseAttribute(HttpStatusCode code)
+            : this(code, null, null) { }
+
+        public SwaggerResponseAttribute(HttpStatusCode code, string message)
+            : this(code, message, null) { }
+
+        public SwaggerResponseAttribute(HttpStatusCode code, Type responseModel)
+            : this(code, null, responseModel) { }
+
+        public SwaggerResponseAttribute(HttpStatusCode code, string message, Type model)
+        {
+            Code = code;
+            Message = message ?? code.ToString();
+            Model = model;
+        }
+
+        public HttpStatusCode Code { get; private set; }
+
+        public string Message { get; set; }
+
+        public Type Model { get; set; }
+    }
+}

--- a/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
+++ b/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Attributes\SwaggerModelPropertyAttribute.cs" />
     <Compile Include="Attributes\SwaggerRouteAttribute.cs" />
     <Compile Include="Attributes\SwaggerRouteParamAttribute.cs" />
+    <Compile Include="Attributes\SwaggerResponse.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RouteId.cs" />

--- a/src/Nancy.Swagger.Annotations/SwaggerAnnotationsConverter.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerAnnotationsConverter.cs
@@ -1,6 +1,7 @@
 ﻿using Nancy.Routing;
 using Nancy.Swagger.Annotations.Attributes;
 using Nancy.Swagger.Services;
+using Swagger.ObjectModel;
 using Swagger.ObjectModel.ApiDeclaration;
 using System;
 using System.Collections.Generic;
@@ -132,6 +133,24 @@ namespace Nancy.Swagger.Annotations
                 data.OperationNotes = attr.Notes ?? data.OperationNotes;
                 data.OperationModel = attr.Response ?? data.OperationModel;
             }
+
+            data.OperationResponseMessages = handler.GetAttributes<SwaggerResponseAttribute>()
+                .Select(attr => {
+                    var msg = new ResponseMessage
+                    {
+                        Code = (int)attr.Code,
+                        Message = attr.Message                    
+                    };
+                    
+                    if (attr.Model != null) 
+                    {
+                        msg.ResponseModel = Primitive.IsPrimitive(attr.Model) ? Primitive.FromType(attr.Model).Type : attr.Model.DefaultModelId();
+                    }
+
+                    return msg;
+                })
+                .ToList();
+
 
             data.OperationParameters = handler.GetParameters()
                 .Select(CreateSwaggerParameterData)

--- a/src/Nancy.Swagger/SwaggerExtensions.cs
+++ b/src/Nancy.Swagger/SwaggerExtensions.cs
@@ -34,7 +34,7 @@ namespace Nancy.Swagger
             operation.Method = routeData.OperationMethod;
             operation.Notes = routeData.OperationNotes;
             operation.Parameters = routeData.OperationParameters.Select(p => p.ToParameter());
-            operation.ResponseMessages = routeData.OperationResponseMessages;
+            operation.ResponseMessages = routeData.OperationResponseMessages.OrderBy(r => r.Code);
             operation.Produces = routeData.OperationProduces;
             operation.Consumes = routeData.OperationConsumes;
 

--- a/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_TestModulePath_ReturnsApiDeclaration.approved.txt
+++ b/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_TestModulePath_ReturnsApiDeclaration.approved.txt
@@ -117,7 +117,24 @@
                         }
                     ],
                     "responseMessages":[
-                        
+                        {
+                            "code":200,
+                            "message":"Everything OK",
+                            "responseModel":"TestModel"
+                        },
+                        {
+                            "code":404,
+                            "message":"NotFound"
+                        },
+                        {
+                            "code":418,
+                            "message":"I'm a teapot"
+                        },
+                        {
+                            "code":500,
+                            "message":"InternalServerError",
+                            "responseModel":"string"
+                        }
                     ],
                     "produces":[
                         

--- a/test/Nancy.Swagger.Annotations.Tests/TestRoutesModule.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/TestRoutesModule.cs
@@ -89,6 +89,10 @@ namespace Nancy.Swagger.Annotations.Tests
         }
 
         [SwaggerRoute(HttpMethod.Post, "/models/{id}")]
+        [SwaggerResponse(HttpStatusCode.NotFound)]
+        [SwaggerResponse(HttpStatusCode.ImATeapot, "I'm a teapot")]
+        [SwaggerResponse(HttpStatusCode.InternalServerError, Model = typeof(string))]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "Everything OK", Model = typeof(TestModel))] 
         private dynamic PostModel(
             [SwaggerRouteParam(ParameterType.Body, Required = true)] TestModel testModel
         )


### PR DESCRIPTION
Implements #21: <code>SwaggerRouteResponseAttribute</code>

Examples

``` csharp
[SwaggerRoute(HttpMethod.Post, "/models/{id}")]
[SwaggerRouteResponse(HttpStatusCode.NotFound)]
[SwaggerRouteResponse(HttpStatusCode.ImATeapot, "I'm a teapot")]
[SwaggerRouteResponse(HttpStatusCode.InternalServerError, Model = typeof(string))]
[SwaggerRouteResponse(HttpStatusCode.OK, Message = "Everything OK", Model = typeof(TestModel))] 
private dynamic PostModel(
    [SwaggerRouteParam(ParameterType.Body, Required = true)] TestModel testModel
)
{
    // ...
}
```
