### PR TITLE
Avoid model id collisions when two types have the same name

### DIFF
--- a/src/Nancy.Swagger.Annotations/SwaggerAnnotationsConverter.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerAnnotationsConverter.cs
@@ -146,7 +146,9 @@ namespace Nancy.Swagger.Annotations
                     
                     if (attr.Model != null) 
                     {
-                        msg.ResponseModel = Primitive.IsPrimitive(attr.Model) ? Primitive.FromType(attr.Model).Type : attr.Model.DefaultModelId();
+                        msg.ResponseModel = Primitive.IsPrimitive(attr.Model) 
+                                                ? Primitive.FromType(attr.Model).Type
+                                                : SwaggerConfig.ModelIdConvention(attr.Model);
                     }
 
                     return msg;

--- a/src/Nancy.Swagger/SwaggerExtensions.cs
+++ b/src/Nancy.Swagger/SwaggerExtensions.cs
@@ -84,18 +84,18 @@ namespace Nancy.Swagger
                     return dataType;
                 }
 
-                dataType.Items = new Items { Ref = itemsType.DefaultModelId() };
+                dataType.Items = new Items { Ref = SwaggerConfig.ModelIdConvention(itemsType) };
 
                 return dataType;
             }
 
             if (isTopLevel)
             {
-                dataType.Ref = type.DefaultModelId();
+                dataType.Ref = SwaggerConfig.ModelIdConvention(type);
                 return dataType;
             }
 
-            dataType.Type = type.DefaultModelId();
+            dataType.Type = SwaggerConfig.ModelIdConvention(type);
 
             return dataType;
         }
@@ -165,7 +165,7 @@ namespace Nancy.Swagger
 
                 var id = modelDataForClassProperty == null
                     ? swaggerModelPropertyData.Type.Name
-                    : modelDataForClassProperty.ModelType.DefaultModelId();
+                    : SwaggerConfig.ModelIdConvention(modelDataForClassProperty.ModelType);
 
                 var description = modelDataForClassProperty == null
                     ? swaggerModelPropertyData.Description
@@ -198,7 +198,7 @@ namespace Nancy.Swagger
 
             var topLevelModel = new Model
             {
-                Id = model.ModelType.DefaultModelId(),
+                Id = SwaggerConfig.ModelIdConvention(model.ModelType),
                 Description = model.Description,
                 Required = model.Properties
                     .Where(p => p.Required || p.Type.IsImplicitlyRequired())
@@ -235,15 +235,6 @@ namespace Nancy.Swagger
             }
 
             return modelProperty;
-        }
-
-        public static string DefaultModelId(this Type type)
-        {
-            // TODO: This won't scale as you'd get collisions between types with the same 
-            // name but different namespace. Could use FullName, but that's a bit fugly. 
-            // perhaps this is a reasonable default but the DSL could provide a facility for 
-            // overriding a given model's ID?
-            return type.Name;
         }
 
         private static HttpMethod Convert(string method)

--- a/test/Nancy.Swagger.Annotations.Tests/Nancy.Swagger.Annotations.Tests.csproj
+++ b/test/Nancy.Swagger.Annotations.Tests/Nancy.Swagger.Annotations.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="SwaggerAnnotationsConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestModel.cs" />
+    <Compile Include="TestModel.InOtherNamespace.cs" />
     <Compile Include="TestRoutesModule.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_TestModulePath_ReturnsApiDeclaration.approved.json
+++ b/test/Nancy.Swagger.Annotations.Tests/SwaggerAnnotationsConverterTests.Get_TestModulePath_ReturnsApiDeclaration.approved.json
@@ -153,6 +153,17 @@
             ]
         },
         {
+            "path": "/testroutes/model-with-duplicate-typename",
+            "operations": [
+                {
+                    "method": "GET",
+                    "nickname": "getTestroutesModelWithDuplicateTypename",
+                    "parameters": [],
+                    "type": "InOtherNamespaceTestModel"
+                }
+            ]
+        },
+        {
             "path": "/testroutes/namedroute",
             "operations": [
                 {
@@ -230,6 +241,11 @@
         }
     ],
     "models": {
+        "InOtherNamespaceTestModel": {
+            "id": "InOtherNamespaceTestModel",
+            "required": [],
+            "properties": {}
+        },
         "TestModel": {
             "id": "TestModel",
             "description": "Description of a model",

--- a/test/Nancy.Swagger.Annotations.Tests/TestModel.InOtherNamespace.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/TestModel.InOtherNamespace.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nancy.Swagger.Annotations.Tests.InOtherNamespace
+{
+    public class TestModel
+    {
+    }
+}

--- a/test/Nancy.Swagger.Annotations.Tests/TestRoutesModule.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/TestRoutesModule.cs
@@ -30,6 +30,14 @@ namespace Nancy.Swagger.Annotations.Tests
             // Misc other cases
             Get["GetNamedRoute", "/namedroute"] = _ => GetNamedRoute();
             Get["/allowmultipleparam"] = _ => GetWithAllowMultipleParam(Request.Query.ids);
+            Get["/model-with-duplicate-typename"] = _ => GetModelWithDuplicateTypeName();
+        }
+
+        [SwaggerRoute(HttpMethod.Get, "/model-with-duplicate-typename")]
+        [SwaggerRoute(Response=typeof(InOtherNamespace.TestModel))]
+        private dynamic GetModelWithDuplicateTypeName()
+        {
+            throw new NotImplementedException();
         }
 
         [SwaggerRoute(HttpMethod.Get, "/allowmultipleparam")]

--- a/test/Nancy.Swagger.Tests/SwaggerExtensionsTests.cs
+++ b/test/Nancy.Swagger.Tests/SwaggerExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Nancy.Swagger.Tests
             }.ToModelProperty().ShouldEqual(
                 new ModelProperty
                 {
-                    Ref = typeof(TestModel).DefaultModelId()
+                    Ref = SwaggerConfig.ModelIdConvention(typeof(TestModel))
                 }
             );
         }
@@ -62,7 +62,7 @@ namespace Nancy.Swagger.Tests
                 new ModelProperty
                 {
                     Type = "array",
-                    Items = new Items { Ref = typeof(TestModel).DefaultModelId() }
+                    Items = new Items { Ref = SwaggerConfig.ModelIdConvention(typeof(TestModel)) }
                 },
                 "String return type"
             );
@@ -80,8 +80,7 @@ namespace Nancy.Swagger.Tests
                 {
                     Method = HttpMethod.Get,
                     Nickname = "get",
-                    Type = typeof(TestModel).DefaultModelId(),
-                    Parameters = Enumerable.Empty<Parameter>()
+                    Type = SwaggerConfig.ModelIdConvention(typeof(TestModel)),                    Parameters = Enumerable.Empty<Parameter>()
                 }
             );
         }
@@ -99,7 +98,7 @@ namespace Nancy.Swagger.Tests
                     Method = HttpMethod.Get,
                     Nickname = "get",
                     Type = "array",
-                    Items = new Items { Ref = typeof(TestModel).DefaultModelId() },
+                    Items = new Items { Ref = SwaggerConfig.ModelIdConvention(typeof(TestModel)) },
                     Parameters = Enumerable.Empty<Parameter>()
                 },
                 "String return type"
@@ -172,7 +171,7 @@ namespace Nancy.Swagger.Tests
                 {
                     Name = "body",
                     ParamType = ParameterType.Body,
-                    Type = typeof(TestModel).DefaultModelId(),
+                    Type = SwaggerConfig.ModelIdConvention(typeof(TestModel)),
                 },
                 "Type field MUST be used to link to other models."
             );
@@ -191,7 +190,7 @@ namespace Nancy.Swagger.Tests
                 {
                     Name = "body",
                     ParamType = ParameterType.Body,
-                    Type = typeof(TestModel).DefaultModelId(),
+                    Type = SwaggerConfig.ModelIdConvention(typeof(TestModel)),
                 },
                 "If paramType is \"body\", the name is used only for Swagger-UI and Swagger-Codegen. In this case, the name MUST be \"body\"."
             );
@@ -209,7 +208,7 @@ namespace Nancy.Swagger.Tests
                 {
                     Name = "body",
                     ParamType = ParameterType.Body,
-                    Type = typeof(TestModel).DefaultModelId(),
+                    Type = SwaggerConfig.ModelIdConvention(typeof(TestModel)),
                 },
                 "If paramType is \"body\", the name is used only for Swagger-UI and Swagger-Codegen. In this case, the name MUST be \"body\"."
             );


### PR DESCRIPTION
This PR provides a solution for the problem @liddellj mentioned in the comments:

``` csharp
public static string DefaultModelId(this Type type)
{
    // TODO: This won't scale as you'd get collisions between types with the same 
    // name but different namespace. Could use FullName, but that's a bit fugly. 
    // perhaps this is a reasonable default but the DSL could provide a facility for 
    // overriding a given model's ID?
    return type.Name
}
```

[Ofcourse](http://www.wikiwand.com/en/Murphy's_law) I ran into this problem immediately when trying Nancy.Swagger with some codebase.
I agree returning <code>type.FullName</code> is not very pretty, so instead I renamed <code>DefaultModelId</code> to <code>ResolveModelId</code>. It returns the <code>type.Name</code> if it wasn't resolved by some other type with the same name first. Else, it prepends the last part of the type's namespace and checks again.

So

``` csharp
Console.WriteLine(typeof(Some.MyType).ResolveModelId());
Console.WriteLine(typeof(Some.Other.MyType).ResolveModelId());
```

will output

``` csharp
MyType
OtherMyType
```

The one thing I'm not very happy/sure about is it introduces state (<code>_resolvedModelIds</code>) in <code>SwaggerExtensions</code>.
