### PR TITLE
Embed swagger-ui and expose a SwaggerUIModule

### DIFF
--- a/samples/Nancy.Swagger.Demo/Bootstrapper.cs
+++ b/samples/Nancy.Swagger.Demo/Bootstrapper.cs
@@ -1,15 +1,12 @@
-﻿using Nancy.Conventions;
-
-namespace Nancy.Swagger.Demo
+﻿namespace Nancy.Swagger.Demo
 {
     public class Bootstrapper : DefaultNancyBootstrapper
     {
-        protected override void ConfigureConventions(NancyConventions nancyConventions)
+        protected override void ApplicationStartup(TinyIoc.TinyIoCContainer container, Nancy.Bootstrapper.IPipelines pipelines)
         {
-            base.ConfigureConventions(nancyConventions);
+            SwaggerConfig.SwaggerUIPath = "docs";
 
-            nancyConventions.StaticContentsConventions
-                .Add(StaticContentConventionBuilder.AddDirectory("docs", "swagger-ui"));
+            base.ApplicationStartup(container, pipelines);
         }
     }
 }

--- a/samples/Nancy.Swagger.Demo/Nancy.Swagger.Demo.csproj
+++ b/samples/Nancy.Swagger.Demo/Nancy.Swagger.Demo.csproj
@@ -123,7 +123,8 @@
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>
-    <PreBuildEvent>xcopy "$(SolutionDir)lib\swagger-ui\dist" "$(ProjectDir)swagger-ui" /S /I /Y</PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Nancy.Swagger/Modules/SwaggerUIModule.cs
+++ b/src/Nancy.Swagger/Modules/SwaggerUIModule.cs
@@ -1,0 +1,102 @@
+﻿using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Nancy.Swagger.Modules
+{
+    [SwaggerApi]
+    public class SwaggerUIModule : NancyModule
+    {
+        private static Assembly _executingAssembly = Assembly.GetExecutingAssembly();
+
+        private static string[] _resourceNames = _executingAssembly.GetManifestResourceNames();
+
+        public SwaggerUIModule()
+            : base(SwaggerConfig.SwaggerUIPath)
+        {
+            Get["/"] = _ => GetResource();
+            Get["/{path*}"] = _ => GetResource(_.path);
+        }
+
+        private Response GetResource(string path = null)
+        {
+            if (path == null)
+            {
+                return Response.AsRedirect(SwaggerConfig.SwaggerUIPath + "/index.html");
+            }
+
+            if (GetResourceName(path) == null)
+            {
+                return HttpStatusCode.NotFound;
+            }
+
+            return new Response
+            {
+                ContentType = GetContentType(path),
+                Contents = stream => WriteResource(stream, path)
+            };
+        }
+
+        private void WriteResource(Stream stream, string path)
+        {
+            using (var rs = GetResourceStream(path))
+            {
+                if (IsTextResource(path))
+                {
+                    using (var sr = new StreamReader(rs, Encoding.UTF8))
+                    {
+                        // Poor-man's templating for now
+                        var content = sr.ReadToEnd();
+                        content = content.Replace("{{ResourceListingPath}}", Request.Url.SiteBase + "/" + SwaggerConfig.ResourceListingPath);
+                        using (var sw = new StreamWriter(stream))
+                        {
+                            sw.Write(content);
+                        }
+                    }
+                }
+                else
+                {
+                    rs.CopyTo(stream);
+                }
+            }
+        }
+
+        private static string GetContentType(string path)
+        {
+            switch (Path.GetExtension(path))
+            {
+                case ".html": return "text/html";
+                case ".js": return "application/javascript";
+                case ".css": return "text/css";
+                case ".png": return "image/png";
+                default: return "text/html";
+            }
+        }
+
+        private static string GetResourceName(string path)
+        {
+            // HACK: linked files as embedded resources have a resource name without extension, so
+            //       remove the extension from the name
+
+            var name = path.Replace('/', '.');
+            var nameWithoutExtension = name.Substring(0, path.LastIndexOf('.'));
+
+            var defaultName = "Nancy.Swagger.Resources.swagger_ui." + nameWithoutExtension;
+            var customName = "Nancy.Swagger.Resources.swagger_ui_custom." + name;
+
+            return _resourceNames.FirstOrDefault(n => n == customName)
+                ?? _resourceNames.FirstOrDefault(n => n == defaultName);
+        }
+
+        private static Stream GetResourceStream(string path)
+        {
+            return _executingAssembly.GetManifestResourceStream(GetResourceName(path));
+        }
+
+        private static bool IsTextResource(string path)
+        {
+            return new [] { ".html", ".css", ".js" }.Contains(Path.GetExtension(path));
+        }
+    }
+}

--- a/src/Nancy.Swagger/Nancy.Swagger.csproj
+++ b/src/Nancy.Swagger/Nancy.Swagger.csproj
@@ -50,6 +50,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ISwaggerModelCatalog.cs" />
+    <Compile Include="Modules\SwaggerUIModule.cs" />
     <Compile Include="Services\DefaultSwaggerModelCatalog.cs" />
     <Compile Include="Services\ISwaggerModelDataProvider.cs" />
     <Compile Include="Services\SwaggerMetadataConverter.cs" />
@@ -79,6 +80,14 @@
       <Project>{140262c2-a8be-4c8f-9a2f-b848ef396b91}</Project>
       <Name>Swagger.ObjectModel</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\lib\swagger-ui\dist\**\*.*">
+      <Link>Resources\swagger-ui\%(RecursiveDir)%(FileName)</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\swagger-ui-custom\index.html" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Fody.1.24.0\build\Fody.targets" Condition="Exists('..\..\packages\Fody.1.24.0\build\Fody.targets')" />

--- a/src/Nancy.Swagger/Resources/swagger-ui-custom/index.html
+++ b/src/Nancy.Swagger/Resources/swagger-ui-custom/index.html
@@ -1,0 +1,88 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+	<title>Swagger UI</title>
+	<link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css' />
+	<link href='css/reset.css' media='screen' rel='stylesheet' type='text/css' />
+	<link href='css/screen.css' media='screen' rel='stylesheet' type='text/css' />
+	<link href='css/reset.css' media='print' rel='stylesheet' type='text/css' />
+	<link href='css/screen.css' media='print' rel='stylesheet' type='text/css' />
+	<script type="text/javascript" src="lib/shred.bundle.js"></script>
+	<script src='lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+	<script src='lib/jquery.slideto.min.js' type='text/javascript'></script>
+	<script src='lib/jquery.wiggle.min.js' type='text/javascript'></script>
+	<script src='lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+	<script src='lib/handlebars-1.0.0.js' type='text/javascript'></script>
+	<script src='lib/underscore-min.js' type='text/javascript'></script>
+	<script src='lib/backbone-min.js' type='text/javascript'></script>
+	<script src='lib/swagger.js' type='text/javascript'></script>
+	<script src='swagger-ui.js' type='text/javascript'></script>
+	<script src='lib/highlight.7.3.pack.js' type='text/javascript'></script>
+
+	<!-- enabling this will enable oauth2 implicit scope support -->
+	<script src='lib/swagger-oauth.js' type='text/javascript'></script>
+
+	<script type="text/javascript">
+    $(function () {
+      window.swaggerUi = new SwaggerUi({
+      url: "{{ResourceListingPath}}",
+      dom_id: "swagger-ui-container",
+      supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
+      onComplete: function(swaggerApi, swaggerUi){
+        log("Loaded SwaggerUI");
+
+        if(typeof initOAuth == "function") {
+          /*
+          initOAuth({
+            clientId: "your-client-id",
+            realm: "your-realms",
+            appName: "your-app-name"
+          });
+          */
+        }
+        $('pre code').each(function(i, e) {
+          hljs.highlightBlock(e)
+        });
+      },
+      onFailure: function(data) {
+        log("Unable to Load SwaggerUI");
+      },
+      docExpansion: "none",
+      sorter : "alpha"
+    });
+
+    $('#input_apiKey').change(function() {
+      var key = $('#input_apiKey')[0].value;
+      log("key: " + key);
+      if(key && key.trim() != "") {
+        log("added key " + key);
+        window.authorizations.add("key", new ApiKeyAuthorization("api_key", key, "query"));
+      }
+    })
+    window.swaggerUi.load();
+  });
+	</script>
+</head>
+
+<body class="swagger-section">
+	<div id='header'>
+		<div class="swagger-ui-wrap">
+			<a id="logo" href="http://swagger.wordnik.com">swagger</a>
+			<form id='api_selector'>
+				<div class='input icon-btn'>
+					<img id="show-pet-store-icon" src="images/pet_store_api.png" title="Show Swagger Petstore Example Apis">
+				</div>
+				<div class='input icon-btn'>
+					<img id="show-wordnik-dev-icon" src="images/wordnik_api.png" title="Show Wordnik Developer Apis">
+				</div>
+				<div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text" /></div>
+				<div class='input'><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text" /></div>
+				<div class='input'><a id="explore" href="#">Explore</a></div>
+			</form>
+		</div>
+	</div>
+
+	<div id="message-bar" class="swagger-ui-wrap">&nbsp;</div>
+	<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+</body>
+</html>

--- a/src/Nancy.Swagger/SwaggerConfig.cs
+++ b/src/Nancy.Swagger/SwaggerConfig.cs
@@ -15,8 +15,11 @@ namespace Nancy.Swagger
         /// </summary>
         public const string DefaultResourceListingPath = "api-docs";
 
+        public const string DefaultSwaggerUIPath = "swagger-ui";
+
         static SwaggerConfig()
         {
+            SwaggerUIPath = DefaultSwaggerUIPath;
             ResourceListingPath = DefaultResourceListingPath;
             ModelIdConvention = DefaultModelIdConvention;
             NicknameConvention = DefaultNicknameConvention;        
@@ -39,6 +42,8 @@ namespace Nancy.Swagger
         /// Default value is <see cref="DefaultResourceListingPath"/>.
         /// </summary>
         public static string ResourceListingPath { get; set; }
+
+        public static string SwaggerUIPath { get; set; }        
 
         /// <summary>
         /// Returns a unique model id for the given <paramref name="type"/>. 


### PR DESCRIPTION
@khellang wrote about embedding swagger-ui in some past issues/pull-requests. I hadn't done anything like this before and I was curious about how to do something like this. So I tried some things.

I came to a working solution, which is in this PR but I don't have a clue if this is the way to go. But it might be worth sharing. I did the following:

Embedded swagger-ui in <code>Nancy.Swagger</code> by adding the following into the csrpoj

``` xml
<ItemGroup>
    <EmbeddedResource Include="..\..\lib\swagger-ui\dist\**\*.*">
        <Link>Resources\swagger-ui\%(RecursiveDir)%(FileName)</Link>
    </EmbeddedResource>
</ItemGroup>
```

I added a <code>SwaggerUIModule</code> which serves the embedded resources and made the swagger-ui path configurable by <code>SwaggerConfig.SwaggerUIPath</code>.
I had to use some dark, black string-magic to get from a path to the embedded resource name. Not very proud of it, but it seems to do the job.

I added a custom <code>index.html</code> next to the swagger-ui's, since I thought it might be nice to set the path to the Swagger API docs by default:

``` javascript
$(function () {
      window.swaggerUi = new SwaggerUi({
      url: "{{ResourceListingPath}}",
// ...
```

The last change in this PR is removing the post-build event in the Demo project, since swagger-ui is embedded now.

As said above, I have absolutely no idea if this is the way to go but it might be a start :grimacing: 
