### PR TITLE
Added demo projects for the annotations approach

### DIFF
--- a/Nancy.Swagger.sln
+++ b/Nancy.Swagger.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nancy.Swagger", "src\Nancy.Swagger\Nancy.Swagger.csproj", "{ADD1E494-A985-4F8D-911B-E487D4B3159E}"
 EndProject
@@ -27,6 +27,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "etc", "etc", "{EA3F2EA3-B5D
 	ProjectSection(SolutionItems) = preProject
 		etc\CommonAssemblyInfo.cs = etc\CommonAssemblyInfo.cs
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nancy.Swagger.Annotations.Demo", "samples\Nancy.Swagger.Annotations.Demo\Nancy.Swagger.Annotations.Demo.csproj", "{A4D96B84-C68E-4DA1-9325-D445225F1DCB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nancy.Swagger.Annotations.Demo.JsonNet", "samples\Nancy.Swagger.Annotations.Demo.JsonNet\Nancy.Swagger.Annotations.Demo.JsonNet.csproj", "{AFF7B54D-0EE1-47E6-8340-28A0D2206A23}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -62,6 +66,14 @@ Global
 		{367BF53D-1FD7-4CC8-9154-A2B2AF87871F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{367BF53D-1FD7-4CC8-9154-A2B2AF87871F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{367BF53D-1FD7-4CC8-9154-A2B2AF87871F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4D96B84-C68E-4DA1-9325-D445225F1DCB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4D96B84-C68E-4DA1-9325-D445225F1DCB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4D96B84-C68E-4DA1-9325-D445225F1DCB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4D96B84-C68E-4DA1-9325-D445225F1DCB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFF7B54D-0EE1-47E6-8340-28A0D2206A23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFF7B54D-0EE1-47E6-8340-28A0D2206A23}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFF7B54D-0EE1-47E6-8340-28A0D2206A23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFF7B54D-0EE1-47E6-8340-28A0D2206A23}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -74,6 +86,8 @@ Global
 		{10A7F49B-B1EE-41FE-BE88-8AB59AA3319F} = {F2196CF4-15EE-4790-8891-277DAF6BE526}
 		{D64692AA-80A4-4C31-B921-18BDEA18BB03} = {F6D6A272-5D62-45E8-9681-74FEB31BEAD1}
 		{367BF53D-1FD7-4CC8-9154-A2B2AF87871F} = {06F8EE55-908F-4FA4-81F7-E0ECE9FBA3AC}
+		{A4D96B84-C68E-4DA1-9325-D445225F1DCB} = {06F8EE55-908F-4FA4-81F7-E0ECE9FBA3AC}
+		{AFF7B54D-0EE1-47E6-8340-28A0D2206A23} = {06F8EE55-908F-4FA4-81F7-E0ECE9FBA3AC}
 	EndGlobalSection
 	GlobalSection(CodealikeProperties) = postSolution
 		SolutionGuid = 490b2a4f-22f5-46a2-93a9-b929191d1f55

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Bootstrapper.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Bootstrapper.cs
@@ -1,0 +1,21 @@
+﻿using Nancy.Bootstrapper;
+using Nancy.Conventions;
+using Nancy.Swagger.Services;
+using Nancy.TinyIoc;
+
+namespace Nancy.Swagger.Annotations.Demo.JsonNet
+{
+    public class Bootstrapper : DefaultNancyBootstrapper
+    {
+        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
+        {
+            // Register our custom JsonNetAnnotationsProvider, this overrules the default metadata provder
+            container.Register<ISwaggerMetadataProvider, JsonNetAnnotationsProvider>();
+        }
+
+        protected override void ConfigureConventions(NancyConventions nancyConventions)
+        {
+            nancyConventions.StaticContentsConventions.AddDirectory("docs", "swagger-ui");
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/JsonNetAnnotationsProvider.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/JsonNetAnnotationsProvider.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Nancy.Swagger.Services;
+
+namespace Nancy.Swagger.Annotations.Demo.JsonNet
+{
+    public class JsonNetAnnotationsProvider : ISwaggerMetadataProvider
+    {
+        private readonly SwaggerAnnotationsProvider _internalProvider;
+
+        public JsonNetAnnotationsProvider(SwaggerAnnotationsProvider internalProvider)
+        {
+            _internalProvider = internalProvider;
+        }
+
+        public IList<SwaggerModelData> RetrieveSwaggerModelData()
+        {
+            var result = _internalProvider.RetrieveSwaggerModelData();
+            result.ToList().ForEach(DecorateModel);
+            return result;
+        }
+
+        public IList<SwaggerRouteData> RetrieveSwaggerRouteData()
+        {
+            return _internalProvider.RetrieveSwaggerRouteData();
+        }
+
+        private static void DecorateModel(SwaggerModelData model)
+        {
+            foreach (var attr in GetAttributes(model.ModelType, "Newtonsoft.Json.JsonObjectAttribute"))
+            {
+                var type = attr.GetType();
+                model.Description = GetPropertyValue<string>(type, attr, "Description") ?? model.Description;
+            }
+
+            model.Properties
+                .ToList()
+                .ForEach(p => DecorateModelProperty(model, p));
+        }
+
+        private static void DecorateModelProperty(SwaggerModelData model, SwaggerModelPropertyData property)
+        {
+            var propertyInfo = GetPropertyInfo(model, property);
+            foreach (var attr in GetAttributes(propertyInfo, "Newtonsoft.Json.JsonPropertyAttribute"))
+            {
+                var type = attr.GetType();
+
+                property.Name = GetPropertyValue<string>(type, attr, "PropertyName") ?? property.Name;
+
+                var required = GetPropertyValue<object>(type, attr, "Required");
+                if (required != null && required.ToString() == "Always")
+                {
+                    property.Required = true;
+                }
+            }
+        }
+
+        private static PropertyInfo GetPropertyInfo(SwaggerModelData model, SwaggerModelPropertyData property)
+        {
+            return model.ModelType.GetProperty(property.Name);
+        }
+
+        private static T GetPropertyValue<T>(Type type, object obj, string propertyName)
+        {
+            var value = type.GetProperty(propertyName).GetValue(obj, null);
+
+            return value == null ? default(T) : (T) value;
+        }
+
+        private static IList<Attribute> GetAttributes(MemberInfo memberInfo, string attrFullTypeName)
+        {
+            return memberInfo.GetCustomAttributes(true)
+                .Cast<Attribute>()
+                .Where(attr => attr.GetType().FullName == attrFullTypeName)
+                .ToList();
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/Category.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/Category.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Nancy.Swagger.Annotations.Demo.JsonNet.Models
+{
+    public class Category
+    {
+        [JsonProperty("id", Required = Required.Always)]
+        public long Id { get; set; }
+
+        [JsonProperty("name", Required = Required.Always)]
+        public String Name { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/Order.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/Order.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Nancy.Swagger.Annotations.Attributes;
+using Newtonsoft.Json;
+
+namespace Nancy.Swagger.Annotations.Demo.JsonNet.Models
+{
+    public class Order
+    {
+        [JsonProperty("id", Required = Required.Always)]
+        public long Id { get; set; }
+
+        [JsonProperty("complete", Required = Required.Always)]
+        public bool Complete { get; set; }
+
+        [JsonProperty("petId", Required = Required.Always)]
+        public long PetId { get; set; }
+
+        [JsonProperty("quantity", Required = Required.Always)]
+        public int Quantity { get; set; }
+
+        [JsonProperty("shipDate", Required = Required.Always)]
+        public DateTime ShipDate { get; set; }
+
+        [JsonProperty("shipDate", Required = Required.Always)]
+        [ModelProperty(Description = "Order Status")]
+        [ModelProperty(Enum = new[] { "placed", "approved", "delivered" })]
+        public String Status { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/Pet.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/Pet.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using Nancy.Swagger.Annotations.Attributes;
+using Newtonsoft.Json;
+
+namespace Nancy.Swagger.Annotations.Demo.JsonNet.Models
+{
+    public class Pet
+    {
+
+        [JsonProperty("id", Required = Required.Always)]
+        public long Id { get; set; }
+
+        [JsonProperty("category")]
+        public Category Category { get; set; }
+
+
+        [JsonProperty("name", Required = Required.Always)]
+        public string Name { get; set; }
+
+        [JsonProperty("photoUrls", Required = Required.Always)]
+        public List<string> PhotoUrls { get; set; }
+
+
+        [JsonProperty("tags", Required = Required.Always)]
+        public List<Tag> Tags { get; set; }
+        
+        [JsonProperty("status", Required = Required.Always)]
+        [ModelProperty(Description = "pet status in the store")]
+        [ModelProperty(Enum = new[] {"available", "pending", "sold"})]
+        public String Status { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/Tag.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/Tag.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Nancy.Swagger.Annotations.Demo.JsonNet.Models
+{
+    public class Tag
+    {
+        [JsonProperty("id", Required = Required.Always)]
+        public long Id { get; set; }
+
+        [JsonProperty("name", Required = Required.Always)]
+        public String Name { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/User.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Models/User.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+
+namespace Nancy.Swagger.Annotations.Demo.JsonNet.Models
+{
+    public class User
+    {
+        [JsonProperty("email", Required = Required.Always)]
+        public string Email { get; set; }
+        
+        [JsonProperty("firstName", Required = Required.Always)]
+        public string FirstName { get; set; }
+
+        [JsonProperty("id", Required = Required.Always)]
+        public long Id { get; set; }
+
+        [JsonProperty("lastName", Required = Required.Always)]
+        public string LastName { get; set; }
+
+        [JsonProperty("password", Required = Required.Always)]
+        public string Password { get; set; }
+
+        [JsonProperty("phone", Required = Required.Always)]
+        public string Phone { get; set; }
+
+        [JsonProperty("userStatus", Required = Required.Always)]
+        public int UserStatus { get; set; }
+
+        [JsonProperty("username", Required = Required.Always)]
+        public string Username { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Modules/PetsModule.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Modules/PetsModule.cs
@@ -17,7 +17,7 @@ namespace Nancy.Swagger.Annotations.Demo.JsonNet.Modules
 
         [Route(HttpMethod.Post, "")]
         [Route(Summary = "Add a new pet to the store")]
-        [SwaggerResponse(HttpStatusCode.MethodNotAllowed, "Invalid input")]
+        [Response(HttpStatusCode.MethodNotAllowed, "Invalid input")]
         private static dynamic AddNewPet(
             [RouteParam(ParameterType.Body)]
             [RouteParam(Description = "Pet object that needs to be added to the store")] 
@@ -30,9 +30,9 @@ namespace Nancy.Swagger.Annotations.Demo.JsonNet.Modules
 
         [Route(HttpMethod.Put, "")]
         [Route(Summary = "Update an existing pet")]
-        [SwaggerResponse(HttpStatusCode.BadRequest, "Invalid ID supplied")]
-        [SwaggerResponse(HttpStatusCode.NotFound, "Pet not found")]
-        [SwaggerResponse(HttpStatusCode.MethodNotAllowed, "Validation exception")]
+        [Response(HttpStatusCode.BadRequest, "Invalid ID supplied")]
+        [Response(HttpStatusCode.NotFound, "Pet not found")]
+        [Response(HttpStatusCode.MethodNotAllowed, "Validation exception")]
         private static dynamic UpdatePet(
             [RouteParam(ParameterType.Body)]
             [RouteParam(Description = "Pet object that needs to be updated in the store")] 

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Modules/PetsModule.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Modules/PetsModule.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Nancy.ModelBinding;
+using Nancy.Swagger.Annotations.Attributes;
+using Nancy.Swagger.Annotations.Demo.JsonNet.Models;
+using Swagger.ObjectModel.ApiDeclaration;
+
+namespace Nancy.Swagger.Annotations.Demo.JsonNet.Modules
+{
+    public class PetsModule : NancyModule
+    {
+        public PetsModule()
+            : base("pet")
+        {
+            Post[""] = _ => AddNewPet(this.Bind<Pet>());
+            Put[""] = _ => UpdatePet(this.Bind<Pet>());
+        }
+
+        [Route(HttpMethod.Post, "")]
+        [Route(Summary = "Add a new pet to the store")]
+        [SwaggerResponse(HttpStatusCode.MethodNotAllowed, "Invalid input")]
+        private static dynamic AddNewPet(
+            [RouteParam(ParameterType.Body)]
+            [RouteParam(Description = "Pet object that needs to be added to the store")] 
+
+            Pet pet
+        )
+        {
+            throw new NotImplementedException();
+        }
+
+        [Route(HttpMethod.Put, "")]
+        [Route(Summary = "Update an existing pet")]
+        [SwaggerResponse(HttpStatusCode.BadRequest, "Invalid ID supplied")]
+        [SwaggerResponse(HttpStatusCode.NotFound, "Pet not found")]
+        [SwaggerResponse(HttpStatusCode.MethodNotAllowed, "Validation exception")]
+        private static dynamic UpdatePet(
+            [RouteParam(ParameterType.Body)]
+            [RouteParam(Description = "Pet object that needs to be updated in the store")] 
+            Pet pet
+        )
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Nancy.Swagger.Annotations.Demo.JsonNet.csproj
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Nancy.Swagger.Annotations.Demo.JsonNet.csproj
@@ -1,0 +1,146 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{AFF7B54D-0EE1-47E6-8340-28A0D2206A23}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Nancy.Swagger.Annotations.Demo.JsonNet</RootNamespace>
+    <AssemblyName>Nancy.Swagger.Annotations.Demo.JsonNet</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Nancy">
+      <HintPath>..\..\packages\Nancy.0.23.2\lib\net40\Nancy.dll</HintPath>
+    </Reference>
+    <Reference Include="Nancy.Hosting.Aspnet">
+      <HintPath>..\..\packages\Nancy.Hosting.Aspnet.0.23.2\lib\net40\Nancy.Hosting.Aspnet.dll</HintPath>
+    </Reference>
+    <Reference Include="Nancy.Serialization.JsonNet">
+      <HintPath>..\..\packages\Nancy.Serialization.JsonNet.0.23.2\lib\net40\Nancy.Serialization.JsonNet.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\etc\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Bootstrapper.cs" />
+    <Compile Include="JsonNetAnnotationsProvider.cs" />
+    <Compile Include="Models\Category.cs" />
+    <Compile Include="Models\Order.cs" />
+    <Compile Include="Models\Pet.cs" />
+    <Compile Include="Models\Tag.cs" />
+    <Compile Include="Models\User.cs" />
+    <Compile Include="Modules\PetsModule.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Nancy.Swagger.Annotations\Nancy.Swagger.Annotations.csproj">
+      <Project>{10a7f49b-b1ee-41fe-be88-8ab59aa3319f}</Project>
+      <Name>Nancy.Swagger.Annotations</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Nancy.Swagger\Nancy.Swagger.csproj">
+      <Project>{add1e494-a985-4f8d-911b-e487d4b3159e}</Project>
+      <Name>Nancy.Swagger</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Swagger.ObjectModel\Swagger.ObjectModel.csproj">
+      <Project>{140262c2-a8be-4c8f-9a2f-b848ef396b91}</Project>
+      <Name>Swagger.ObjectModel</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>62781</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:62781/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <PropertyGroup>
+    <PreBuildEvent>xcopy "$(SolutionDir)lib\swagger-ui\dist" "$(ProjectDir)swagger-ui" /S /I /Y</PreBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Properties/AssemblyInfo.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Nancy.Swagger.Annotations.Demo.JsonNet")]
+[assembly: AssemblyDescription("Demo application showing Nancy.Swagger usage when using Json.NET")]
+[assembly: AssemblyProduct("Nancy.Swagger")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("23ca7c76-f914-467d-b0be-8ca141e81d55")]

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Web.Debug.config
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Web.Release.config
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Web.config
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/Web.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" />
+  <httpHandlers>
+      <add verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
+    </httpHandlers></system.web>
+<system.webServer>
+    <validation validateIntegratedModeConfiguration="false" />
+    <httpErrors existingResponse="PassThrough" />
+    <handlers>
+      <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
+    </handlers>
+  </system.webServer></configuration>

--- a/samples/Nancy.Swagger.Annotations.Demo.JsonNet/packages.config
+++ b/samples/Nancy.Swagger.Annotations.Demo.JsonNet/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Nancy" version="0.23.2" targetFramework="net45" />
+  <package id="Nancy.Hosting.Aspnet" version="0.23.2" targetFramework="net45" />
+  <package id="Nancy.Serialization.JsonNet" version="0.23.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+</packages>

--- a/samples/Nancy.Swagger.Annotations.Demo/Bootstrapper.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Bootstrapper.cs
@@ -1,0 +1,23 @@
+﻿using Nancy.Bootstrapper;
+using Nancy.Conventions;
+using Nancy.Swagger.Services;
+using Nancy.TinyIoc;
+
+namespace Nancy.Swagger.Annotations.Demo
+{
+    public class Bootstrapper : DefaultNancyBootstrapper
+    {
+        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
+        {
+            base.ApplicationStartup(container, pipelines);
+
+            // Register the annotations provider. This overrules the default metadata provder
+            container.Register<ISwaggerMetadataProvider, SwaggerAnnotationsProvider>();
+        }
+
+        protected override void ConfigureConventions(NancyConventions nancyConventions)
+        {
+            nancyConventions.StaticContentsConventions.AddDirectory("docs", "swagger-ui");
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Models/Category.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Models/Category.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Nancy.Swagger.Annotations.Demo.Models
+{
+    public class Category
+    {
+        public long Id { get; set; }
+        public String Name { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Models/Order.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Models/Order.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Nancy.Swagger.Annotations.Attributes;
+
+namespace Nancy.Swagger.Annotations.Demo.Models
+{
+    public class Order
+    {
+        public long Id { get; set; }
+        public bool Complete { get; set; }
+        public long PetId { get; set; }
+        public int Quantity { get; set; }
+        public DateTime ShipDate { get; set; }
+
+        [ModelProperty(Description = "Order Status")]
+        [ModelProperty(Enum = new[] {"placed", "approved", "delivered"})]
+        public String Status { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Models/Pet.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Models/Pet.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using Nancy.Swagger.Annotations.Attributes;
+
+namespace Nancy.Swagger.Annotations.Demo.Models
+{
+    public class Pet
+    {
+        public long Id { get; set; }
+        public Category Category { get; set; }
+
+        [ModelProperty(Required = true)]
+        public string Name { get; set; }
+
+        [ModelProperty(Required = true)]
+        public List<string> PhotoUrls { get; set; }
+
+        public List<Tag> Tags { get; set; }
+
+        [ModelProperty(Description = "pet status in the store")]
+        [ModelProperty(Enum = new[] {"available", "pending", "sold"})]
+        public String Status { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Models/Tag.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Models/Tag.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Nancy.Swagger.Annotations.Demo.Models
+{
+    public class Tag
+    {
+        public long Id { get; set; }
+        public String Name { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Models/User.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Models/User.cs
@@ -1,0 +1,14 @@
+﻿namespace Nancy.Swagger.Annotations.Demo.Models
+{
+    public class User
+    {
+        public string Email { get; set; }
+        public string FirstName { get; set; }
+        public long Id { get; set; }
+        public string LastName { get; set; }
+        public string Password { get; set; }
+        public string Phone { get; set; }
+        public int UserStatus { get; set; }
+        public string Username { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Modules/PetsModule.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Modules/PetsModule.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Nancy.ModelBinding;
+using Nancy.Swagger.Annotations.Attributes;
+using Nancy.Swagger.Annotations.Demo.Models;
+using Swagger.ObjectModel.ApiDeclaration;
+
+namespace Nancy.Swagger.Annotations.Demo.Modules
+{
+    public class PetsModule : NancyModule
+    {
+        public PetsModule()
+            : base("pet")
+        {
+            Post[""] = _ => AddNewPet(this.Bind<Pet>());
+            Put[""] = _ => UpdatePet(this.Bind<Pet>());
+        }
+
+        [Route(HttpMethod.Post, "")]
+        [Route(Summary = "Add a new pet to the store")]
+        [SwaggerResponse(HttpStatusCode.MethodNotAllowed, "Invalid input")]
+        private static dynamic AddNewPet(
+            [RouteParam(ParameterType.Body)]
+            [RouteParam(Description = "Pet object that needs to be added to the store")] 
+
+            Pet pet
+        )
+        {
+            throw new NotImplementedException();
+        }
+
+        [Route(HttpMethod.Put, "")]
+        [Route(Summary = "Update an existing pet")]
+        [SwaggerResponse(HttpStatusCode.BadRequest, "Invalid ID supplied")]
+        [SwaggerResponse(HttpStatusCode.NotFound, "Pet not found")]
+        [SwaggerResponse(HttpStatusCode.MethodNotAllowed, "Validation exception")]
+        private static dynamic UpdatePet(
+            [RouteParam(ParameterType.Body)]
+            [RouteParam(Description = "Pet object that needs to be updated in the store")] 
+            Pet pet
+        )
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Modules/PetsModule.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Modules/PetsModule.cs
@@ -17,7 +17,7 @@ namespace Nancy.Swagger.Annotations.Demo.Modules
 
         [Route(HttpMethod.Post, "")]
         [Route(Summary = "Add a new pet to the store")]
-        [SwaggerResponse(HttpStatusCode.MethodNotAllowed, "Invalid input")]
+        [Response(HttpStatusCode.MethodNotAllowed, "Invalid input")]
         private static dynamic AddNewPet(
             [RouteParam(ParameterType.Body)]
             [RouteParam(Description = "Pet object that needs to be added to the store")] 
@@ -30,9 +30,9 @@ namespace Nancy.Swagger.Annotations.Demo.Modules
 
         [Route(HttpMethod.Put, "")]
         [Route(Summary = "Update an existing pet")]
-        [SwaggerResponse(HttpStatusCode.BadRequest, "Invalid ID supplied")]
-        [SwaggerResponse(HttpStatusCode.NotFound, "Pet not found")]
-        [SwaggerResponse(HttpStatusCode.MethodNotAllowed, "Validation exception")]
+        [Response(HttpStatusCode.BadRequest, "Invalid ID supplied")]
+        [Response(HttpStatusCode.NotFound, "Pet not found")]
+        [Response(HttpStatusCode.MethodNotAllowed, "Validation exception")]
         private static dynamic UpdatePet(
             [RouteParam(ParameterType.Body)]
             [RouteParam(Description = "Pet object that needs to be updated in the store")] 

--- a/samples/Nancy.Swagger.Annotations.Demo/Nancy.Swagger.Annotations.Demo.csproj
+++ b/samples/Nancy.Swagger.Annotations.Demo/Nancy.Swagger.Annotations.Demo.csproj
@@ -1,0 +1,140 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A4D96B84-C68E-4DA1-9325-D445225F1DCB}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Nancy.Swagger.Annotations.Demo</RootNamespace>
+    <AssemblyName>Nancy.Swagger.Annotations.Demo</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Nancy">
+      <HintPath>..\..\packages\Nancy.0.23.2\lib\net40\Nancy.dll</HintPath>
+    </Reference>
+    <Reference Include="Nancy.Hosting.Aspnet">
+      <HintPath>..\..\packages\Nancy.Hosting.Aspnet.0.23.2\lib\net40\Nancy.Hosting.Aspnet.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\etc\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Bootstrapper.cs" />
+    <Compile Include="Models\Category.cs" />
+    <Compile Include="Models\Order.cs" />
+    <Compile Include="Models\Pet.cs" />
+    <Compile Include="Models\Tag.cs" />
+    <Compile Include="Models\User.cs" />
+    <Compile Include="Modules\PetsModule.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Nancy.Swagger.Annotations\Nancy.Swagger.Annotations.csproj">
+      <Project>{10a7f49b-b1ee-41fe-be88-8ab59aa3319f}</Project>
+      <Name>Nancy.Swagger.Annotations</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Nancy.Swagger\Nancy.Swagger.csproj">
+      <Project>{add1e494-a985-4f8d-911b-e487d4b3159e}</Project>
+      <Name>Nancy.Swagger</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Swagger.ObjectModel\Swagger.ObjectModel.csproj">
+      <Project>{140262C2-A8BE-4C8F-9A2F-B848EF396B91}</Project>
+      <Name>Swagger.ObjectModel</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>61814</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:61814/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <PropertyGroup>
+    <PreBuildEvent>xcopy "$(SolutionDir)lib\swagger-ui\dist" "$(ProjectDir)swagger-ui" /S /I /Y</PreBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/samples/Nancy.Swagger.Annotations.Demo/Properties/AssemblyInfo.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Nancy.Swagger.Annotations.Demo")]
+[assembly: AssemblyDescription("Demo application showing Nancy.Swagger usage when using the annotations package")]
+[assembly: AssemblyProduct("Nancy.Swagger")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("6ef7bff0-73b1-492c-84c7-4c4ac56960e2")]

--- a/samples/Nancy.Swagger.Annotations.Demo/Web.Debug.config
+++ b/samples/Nancy.Swagger.Annotations.Demo/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/samples/Nancy.Swagger.Annotations.Demo/Web.Release.config
+++ b/samples/Nancy.Swagger.Annotations.Demo/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/samples/Nancy.Swagger.Annotations.Demo/Web.config
+++ b/samples/Nancy.Swagger.Annotations.Demo/Web.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" />
+  <httpHandlers>
+      <add verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
+    </httpHandlers></system.web>
+<system.webServer>
+    <validation validateIntegratedModeConfiguration="false" />
+    <httpErrors existingResponse="PassThrough" />
+    <handlers>
+      <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
+    </handlers>
+  </system.webServer></configuration>

--- a/samples/Nancy.Swagger.Annotations.Demo/packages.config
+++ b/samples/Nancy.Swagger.Annotations.Demo/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Nancy" version="0.23.2" targetFramework="net45" />
+  <package id="Nancy.Hosting.Aspnet" version="0.23.2" targetFramework="net45" />
+</packages>

--- a/src/Nancy.Swagger.Annotations/Attributes/Response.cs
+++ b/src/Nancy.Swagger.Annotations/Attributes/Response.cs
@@ -3,18 +3,18 @@
 namespace Nancy.Swagger.Annotations.Attributes
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
-    public class SwaggerResponseAttribute : Attribute
+    public class ResponseAttribute : Attribute
     {
-        public SwaggerResponseAttribute(HttpStatusCode code)
+        public ResponseAttribute(HttpStatusCode code)
             : this(code, null, null) { }
 
-        public SwaggerResponseAttribute(HttpStatusCode code, string message)
+        public ResponseAttribute(HttpStatusCode code, string message)
             : this(code, message, null) { }
 
-        public SwaggerResponseAttribute(HttpStatusCode code, Type responseModel)
+        public ResponseAttribute(HttpStatusCode code, Type responseModel)
             : this(code, null, responseModel) { }
 
-        public SwaggerResponseAttribute(HttpStatusCode code, string message, Type model)
+        public ResponseAttribute(HttpStatusCode code, string message, Type model)
         {
             Code = code;
             Message = message ?? code.ToString();

--- a/src/Nancy.Swagger.Annotations/SwaggerAnnotationsProvider.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerAnnotationsProvider.cs
@@ -23,10 +23,27 @@ namespace Nancy.Swagger.Annotations
 
         public override IList<SwaggerModelData> RetrieveSwaggerModelData()
         {
-            return RetrieveSwaggerRouteData()
-                    .GetDistinctModelTypes()
-                    .Select(CreateSwaggerModelData)
-                    .ToList();
+            var allTypes = new List<Type>();
+            
+            CollectAllModelTypes(
+                RetrieveSwaggerRouteData().GetDistinctModelTypes(),
+                allTypes
+            );
+
+            return allTypes.Select(CreateSwaggerModelData).ToList();
+        }
+
+        private void CollectAllModelTypes(IEnumerable<Type> types, List<Type> collector)
+        {
+            foreach (var type in types.Where(type => !collector.Contains(type)))
+            {
+                collector.Add(type);
+
+                CollectAllModelTypes(
+                    type.GetProperties().Select(p => p.PropertyType),
+                    collector
+                );
+            }
         }
 
         public override IList<SwaggerRouteData> RetrieveSwaggerRouteData()

--- a/src/Nancy.Swagger.Annotations/SwaggerAnnotationsProvider.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerAnnotationsProvider.cs
@@ -154,7 +154,7 @@ namespace Nancy.Swagger.Annotations
                 data.OperationProduces = attr.Produces ?? data.OperationProduces;
             }
 
-            data.OperationResponseMessages = handler.GetCustomAttributes<SwaggerResponseAttribute>()
+            data.OperationResponseMessages = handler.GetCustomAttributes<ResponseAttribute>()
                 .Select(attr => {
                     var msg = new ResponseMessage
                     {

--- a/src/Nancy.Swagger/SwaggerRegistrations.cs
+++ b/src/Nancy.Swagger/SwaggerRegistrations.cs
@@ -8,7 +8,7 @@ namespace Nancy.Swagger
     {
         public SwaggerRegistrations()
         {
-            RegisterWithDefault<ISwaggerMetadataProvider>(typeof(DefaultSwaggerMetadataProvider));
+            //RegisterWithDefault<ISwaggerMetadataProvider>(typeof(DefaultSwaggerMetadataProvider));
             RegisterWithDefault<ISwaggerMetadataConverter>(typeof(DefaultSwaggerMetadataConverter));
             RegisterWithDefault<ISwaggerModelCatalog>(typeof(DefaultSwaggerModelCatalog));
             RegisterAll<ISwaggerModelDataProvider>();

--- a/test/Nancy.Swagger.Annotations.Tests/TestRoutesModule.cs
+++ b/test/Nancy.Swagger.Annotations.Tests/TestRoutesModule.cs
@@ -103,10 +103,10 @@ namespace Nancy.Swagger.Annotations.Tests
         }
 
         [Route(HttpMethod.Post, "/models/{id}")]
-        [SwaggerResponse(HttpStatusCode.NotFound)]
-        [SwaggerResponse(HttpStatusCode.ImATeapot, "I'm a teapot")]
-        [SwaggerResponse(HttpStatusCode.InternalServerError, Model = typeof(string))]
-        [SwaggerResponse(HttpStatusCode.OK, Message = "Everything OK", Model = typeof(TestModel))] 
+        [Response(HttpStatusCode.NotFound)]
+        [Response(HttpStatusCode.ImATeapot, "I'm a teapot")]
+        [Response(HttpStatusCode.InternalServerError, Model = typeof(string))]
+        [Response(HttpStatusCode.OK, Message = "Everything OK", Model = typeof(TestModel))] 
         private dynamic PostModel(
             [RouteParam(ParameterType.Body, Required = true)] TestModel testModel
         )


### PR DESCRIPTION
I've added two simple demo projects:
- one using the basic annotations package (Nancy.Swagger.Annotations.Demo)
- one using the annotations package with Json.NET (Nancy.Swagger.Annotations.Demo.JsonNet)

They both 'implement' a very small part of the Petstore API, as used in the [Swagger-UI demo](http://petstore.swagger.io/). I can fill in the gaps later, but first I'm having some trouble with the default registrations in Nancy.Swagger.SwaggerRegistrations.cs:

``` csharp
public SwaggerRegistrations()
{
    //RegisterWithDefault<ISwaggerMetadataProvider>(typeof(DefaultSwaggerMetadataProvider));
    RegisterWithDefault<ISwaggerMetadataConverter>(typeof(DefaultSwaggerMetadataConverter));
    RegisterWithDefault<ISwaggerModelCatalog>(typeof(DefaultSwaggerModelCatalog));
    RegisterAll<ISwaggerModelDataProvider>();
}
```

The commented line causes an exception in the Json.NET demo project, because there are two ISwaggerMetadataProvider discovered by `RegisterWithDefault`: `SwaggerAnnotationsProvider` and `JsonNetAnnotationsProvider`.  I'm not sure how to avoid or deal with this. Is this meant behaviour of the RegisterWithDefault functions in Nancy? As i look at Nancy's code I think it is, but how/what should I do to avoid this exception?

The thing I'm basically trying to do is to get the `JsonNetAnnotationsProvider` registered as the `ISwaggerMetadataProvider` to be used in the application. 
`JsonNetAnnotationsProvider` should encapsulate an `ISwaggerMetadataProvider`, and appends extra info to the models provided by the encapsulated ISwaggerMetadataProvider```. 

Could someone help me by explaining me what's the best way to achieve this in Nancy's IoC container?
