### PR TITLE
Fixes license Url typo

### DIFF
--- a/src/Nancy.Swagger.Annotations/project.json
+++ b/src/Nancy.Swagger.Annotations/project.json
@@ -15,7 +15,7 @@
     ],
     "projectUrl": "https://github.com/yahehe/Nancy.Swagger",
     "iconUrl": "http://nancyfx.org/nancy-nuget.png",
-    "licenseUrl": "https://raw.githubusercontent.com/yahehe/Nancy.Swagger/master/LICENSE<",
+    "licenseUrl": "https://raw.githubusercontent.com/yahehe/Nancy.Swagger/master/LICENSE",
     "requireLicenseAcceptance": false,
     "copyright": "Original: Copyright © Kristian Hellang 2014, Continued: Copyright © Ciaran Downey 2017",
     "tags": [

--- a/src/Nancy.Swagger/project.json
+++ b/src/Nancy.Swagger/project.json
@@ -15,7 +15,7 @@
     ],
     "projectUrl": "https://github.com/yahehe/Nancy.Swagger",
     "iconUrl": "http://nancyfx.org/nancy-nuget.png",
-    "licenseUrl": "https://raw.githubusercontent.com/yahehe/Nancy.Swagger/master/LICENSE<",
+    "licenseUrl": "https://raw.githubusercontent.com/yahehe/Nancy.Swagger/master/LICENSE",
     "requireLicenseAcceptance": false,
     "copyright": "Original: Copyright © Kristian Hellang 2014, Continued: Copyright © Ciaran Downey 2017",
     "tags": [

--- a/src/Swagger.ObjectModel/project.json
+++ b/src/Swagger.ObjectModel/project.json
@@ -15,7 +15,7 @@
     ],
     "projectUrl": "https://github.com/yahehe/Nancy.Swagger",
     "iconUrl": "https://raw.githubusercontent.com/yahehe/Nancy.Swagger/master/etc/logo.png",
-    "licenseUrl": "https://raw.githubusercontent.com/yahehe/Nancy.Swagger/master/LICENSE<",
+    "licenseUrl": "https://raw.githubusercontent.com/yahehe/Nancy.Swagger/master/LICENSE",
     "requireLicenseAcceptance": false,
     "copyright": "Original: Copyright © Kristian Hellang 2014, Continued: Copyright © Ciaran Downey 2017",
     "tags": [


### PR DESCRIPTION
I overlooked this copy-paste issue when I transferred the information from the nuspec XML file to the json file.