### PR TITLE
Clean project.json dependencies

### DIFF
--- a/samples/Nancy.Swagger.Annotations.Demo/project.json
+++ b/samples/Nancy.Swagger.Annotations.Demo/project.json
@@ -1,18 +1,11 @@
 ﻿{
   "dependencies": {
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-    "Nancy": "2.0.0-barneyrubble",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
     "Microsoft.AspNetCore.Owin": "1.1.0",
     "HttpMultipartParser": "2.2.3",
-    "Swagger.ObjectModel": {
-      "target": "project"
-    },
-    "Nancy.Swagger": {
-      "target": "project"
-    },
     "Nancy.Swagger.Annotations": {
       "target": "project"
     }
@@ -25,10 +18,6 @@
   "frameworks": {
     "net452": {
       "frameworkAssemblies": {
-        "System.Net": "",
-        "System.Net.Http": "",
-        "System.Text.RegularExpressions": "",
-        "System.Threading.Tasks": "",
         "System.ComponentModel.DataAnnotations": "4.0.0.0"
       }
     }

--- a/samples/Nancy.Swagger.Demo/project.json
+++ b/samples/Nancy.Swagger.Demo/project.json
@@ -1,15 +1,11 @@
 ﻿{
   "dependencies": {
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-    "Nancy": "2.0.0-barneyrubble",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
     "Microsoft.AspNetCore.Owin": "1.1.0",
     "HttpMultipartParser":  "2.2.3",
-    "Swagger.ObjectModel": {
-      "target": "project"
-    },
     "Nancy.Swagger": {
       "target": "project"
     }
@@ -22,10 +18,6 @@
   "frameworks": {
     "net452": {
       "frameworkAssemblies": {
-        "System.Net": "",
-        "System.Net.Http": "",
-        "System.Text.RegularExpressions": "",
-        "System.Threading.Tasks": "",
         "System.ComponentModel.DataAnnotations": "4.0.0.0"
       }
     }

--- a/src/Nancy.Swagger.Annotations/project.json
+++ b/src/Nancy.Swagger.Annotations/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.2.0-*",
+  "version": "2.2.1-*",
   "description": "Provides Swagger data by annotating modules and routes.",
   "authors": [
     "Kristian Hellang",
@@ -26,29 +26,20 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "Nancy": "2.0.0-barneyrubble",
-    "Nancy.Metadata.Modules": "2.0.0-barneyrubble",
-    "Swagger.ObjectModel": {
-      "target": "project"
-    },
     "Nancy.Swagger": {
       "target": "project"
-    },
-    "System.Reflection": "4.1.0"
+    }
   },
 
   "frameworks": {
     "net452": {
-      "frameworkAssemblies": {
-        "System.Net": "",
-        "System.Net.Http": "",
-        "System.Text.RegularExpressions": "",
-        "System.Threading.Tasks": ""
-      }
     },
     "netstandard1.6": {
-      "imports": "dnxcore50"
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.6.0",
+        "System.Reflection": "4.1.0"
+      }
     }
   }
 }

--- a/src/Nancy.Swagger/project.json
+++ b/src/Nancy.Swagger/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.2.0-*",
+  "version": "2.2.1-*",
   "description": "Generated API documentation for Nancy using Swagger.",
   "authors": [
     "Kristian Hellang",
@@ -25,26 +25,20 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
     "Nancy": "2.0.0-barneyrubble",
+    "Nancy.Metadata.Modules": "2.0.0-barneyrubble",
     "Swagger.ObjectModel": {
       "target": "project"
-    },
-    "Nancy.Metadata.Modules": "2.0.0-barneyrubble",
-    "System.Reflection": "4.1.0"
+    }
   },
 
   "frameworks": {
     "net452": {
-      "frameworkAssemblies": {
-        "System.Net": "",
-        "System.Net.Http": "",
-        "System.Text.RegularExpressions": "",
-        "System.Threading.Tasks": ""
-      }
     },
     "netstandard1.6": {
-      "imports": "dnxcore50"
+      "imports": "dnxcore50",
+      "NETStandard.Library": "1.6.0",
+      "System.Reflection": "4.1.0"
     }
   }
 }

--- a/src/Swagger.ObjectModel/project.json
+++ b/src/Swagger.ObjectModel/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0-*",
+  "version": "2.2.1-*",
   "authors": [
     "Kristian Hellang",
     "Ciaran Downey",
@@ -24,24 +24,18 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "System.Dynamic.Runtime": "4.0.11",
-    "System.Runtime.Serialization.Primitives": "4.1.1"
   },
 
   "frameworks": {
     "net452": {
-      "frameworkAssemblies": {
-        "System.Net": "",
-        "System.Net.Http": "",
-        "System.Text.RegularExpressions": "",
-        "System.Threading.Tasks": ""
-      }
     },
     "netstandard1.6": {
       "imports": "dnxcore50",
       "dependencies": {
-        "System.Reflection.TypeExtensions": "4.1.0"
+        "System.Reflection.TypeExtensions": "4.1.0",
+        "NETStandard.Library": "1.6.0",
+        "System.Dynamic.Runtime": "4.0.11",
+        "System.Runtime.Serialization.Primitives": "4.1.1"
       }
     }
   }


### PR DESCRIPTION
Moves NetStandard dependencies under the NetStandard framework section.

And cleans up other references, such as the ones loaded by other included references (e.g., Swagger.ObjectModel is loaded by Nancy.Swagger, so Nancy.Swagger.Annotations only needs to reference Nancy.Swagger directly)