### PR TITLE
Adds auto incrementing of the patch number

### DIFF
--- a/nugetPackageAll.bat
+++ b/nugetPackageAll.bat
@@ -1,3 +1,8 @@
+echo %APPVEYOR_BUILD_NUMBER%
+powershell -Command "(gc src/Nancy.Swagger/project.json) -replace '.0-\*', '.%APPVEYOR_BUILD_NUMBER%-*' | Out-File src/Nancy.Swagger/project.json"
+powershell -Command "(gc src/Nancy.Swagger.Annotations/project.json) -replace '.0-\*', '.%APPVEYOR_BUILD_NUMBER%-*' | Out-File src/Nancy.Swagger.Annotations/project.json"
+powershell -Command "(gc src/Swagger.ObjectModel/project.json) -replace '.0-\*', '.%APPVEYOR_BUILD_NUMBER%-*' | Out-File src/Swagger.ObjectModel/project.json"
+
 dotnet pack src/Nancy.Swagger --configuration Release --output src/Nancy.Swagger/NuGet --version-suffix "alpha"
 dotnet pack src/Nancy.Swagger.Annotations --configuration Release --output src/Nancy.Swagger.Annotations/NuGet --version-suffix "alpha"
 dotnet pack src/Swagger.ObjectModel --configuration Release --output src/Swagger.ObjectModel/NuGet --version-suffix "alpha"

--- a/src/Nancy.Swagger.Annotations/project.json
+++ b/src/Nancy.Swagger.Annotations/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.2.1-*",
+  "version": "2.2.0-*",
   "description": "Provides Swagger data by annotating modules and routes.",
   "authors": [
     "Kristian Hellang",

--- a/src/Nancy.Swagger/project.json
+++ b/src/Nancy.Swagger/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.2.1-*",
+  "version": "2.2.0-*",
   "description": "Generated API documentation for Nancy using Swagger.",
   "authors": [
     "Kristian Hellang",

--- a/src/Swagger.ObjectModel/project.json
+++ b/src/Swagger.ObjectModel/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.1-*",
+  "version": "2.2.0-*",
   "authors": [
     "Kristian Hellang",
     "Ciaran Downey",


### PR DESCRIPTION
This will replace the patch number of the version from a 0 to the app-veyor build number. 

You will want to reset the build number to 2.
And you might want to disable the incrementing of the app-veyor build number on pull requests.

Note: This is a temporary fix until the project.json returns to a .csproj, where you can use the environment variables.