### PR TITLE
Updates RouteDescriber to return the OperationBuilder

### DIFF
--- a/samples/Nancy.Swagger.Demo/Modules/ServiceDetailsMetadataModule.cs
+++ b/samples/Nancy.Swagger.Demo/Modules/ServiceDetailsMetadataModule.cs
@@ -79,7 +79,10 @@ namespace Nancy.Swagger.Demo.Modules
             }, new[]
             {
                 customerSubTag
-            });
+            })
+            //If you need to add something that is not a parameter to DescribeRoute, 
+            //the function will return the OperationBuilder so you can add it.
+            .ProduceMimeTypes(new[] { "multipart/form-data", "application/x-www-form-urlencoded" });
         }
     }
 

--- a/src/Swagger.ObjectModel/Builders/PathItemBuilder.cs
+++ b/src/Swagger.ObjectModel/Builders/PathItemBuilder.cs
@@ -63,6 +63,7 @@ namespace Swagger.ObjectModel.Builders
 
             return item;
         }
+
         /// <summary>
         /// Defines the operation for the path and method;
         /// </summary>
@@ -80,7 +81,18 @@ namespace Swagger.ObjectModel.Builders
             return this;
         }
 
-
+        /// <summary>
+        /// Add a parameter for this operation
+        /// </summary>
+        /// <param name="op">The Operation Builder</param>
+        /// <returns>
+        /// The <see cref="PathItemBuilder"/>.
+        /// </returns>
+        public PathItemBuilder Operation(OperationBuilder op)
+        {
+            op.Build(this.operation);
+            return this;
+        }
 
         /// <summary>
         /// Add a parameter for this operation


### PR DESCRIPTION
Changes the route describer to return the OperationBuilder so that other fields can be added to an operation. This makes the RouteDescriber more useful, while not forcing us to maintain it for any additions to operations, 

RouteDescriber is still just a miscellaneous feature anyways, that just adds extra defaults and processes.