### PR TITLE
Autofac

### DIFF
--- a/Nancy.Swagger.sln
+++ b/Nancy.Swagger.sln
@@ -35,6 +35,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Nancy.Swagger.Demo", "sampl
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Nancy.Swagger.Annotations.Demo", "samples\Nancy.Swagger.Annotations.Demo\Nancy.Swagger.Annotations.Demo.xproj", "{C5C753F1-1CFD-456D-B51F-85F0D8228F3F}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Nancy.Swagger.Autofac.Demo", "samples\Nancy.Swagger.Autofac.Demo\Nancy.Swagger.Autofac.Demo.xproj", "{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -209,6 +211,26 @@ Global
 		{C5C753F1-1CFD-456D-B51F-85F0D8228F3F}.ReleaseNet45|Any CPU.Build.0 = Release|Any CPU
 		{C5C753F1-1CFD-456D-B51F-85F0D8228F3F}.ReleaseNet462|Any CPU.ActiveCfg = Release|Any CPU
 		{C5C753F1-1CFD-456D-B51F-85F0D8228F3F}.ReleaseNet462|Any CPU.Build.0 = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.DebugDotNet|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.DebugDotNet|Any CPU.Build.0 = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.DebugNet40|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.DebugNet40|Any CPU.Build.0 = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.DebugNet45|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.DebugNet45|Any CPU.Build.0 = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.DebugNet462|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.DebugNet462|Any CPU.Build.0 = Debug|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.ReleaseDotNet|Any CPU.ActiveCfg = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.ReleaseDotNet|Any CPU.Build.0 = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.ReleaseNet40|Any CPU.ActiveCfg = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.ReleaseNet40|Any CPU.Build.0 = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.ReleaseNet45|Any CPU.ActiveCfg = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.ReleaseNet45|Any CPU.Build.0 = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.ReleaseNet462|Any CPU.ActiveCfg = Release|Any CPU
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04}.ReleaseNet462|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -222,6 +244,7 @@ Global
 		{41A15D66-32B0-4E0B-B5CD-FCC4DCEECB96} = {F6D6A272-5D62-45E8-9681-74FEB31BEAD1}
 		{A0856D27-2EC2-4AA7-B485-6228462A3906} = {06F8EE55-908F-4FA4-81F7-E0ECE9FBA3AC}
 		{C5C753F1-1CFD-456D-B51F-85F0D8228F3F} = {06F8EE55-908F-4FA4-81F7-E0ECE9FBA3AC}
+		{E8ADAF5D-37A6-4FFB-9F09-CF8FDD4FFA04} = {06F8EE55-908F-4FA4-81F7-E0ECE9FBA3AC}
 	EndGlobalSection
 	GlobalSection(CodealikeProperties) = postSolution
 		SolutionGuid = 490b2a4f-22f5-46a2-93a9-b929191d1f55

--- a/samples/Nancy.Swagger.Annotations.Demo/project.json
+++ b/samples/Nancy.Swagger.Annotations.Demo/project.json
@@ -8,7 +8,9 @@
     "HttpMultipartParser": "2.2.3",
     "Nancy.Swagger.Annotations": {
       "target": "project"
-    }
+    },
+    "Nancy": "2.0.0-clinteastwood",
+    "Nancy.Swagger": "2.2.0-*"
   },
 
   "tools": {
@@ -16,6 +18,15 @@
   },
 
   "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
+      },
+      "imports": "dnxcore50"
+    },
     "net452": {
       "frameworkAssemblies": {
         "System.ComponentModel.DataAnnotations": "4.0.0.0"

--- a/samples/Nancy.Swagger.Autofac.Demo/AutofacBootstrapper.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/AutofacBootstrapper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using System.Threading.Tasks;
+using Autofac;
+using Nancy.Bootstrapper;
+using Nancy.Bootstrappers.Autofac;
+using Nancy.Swagger.Annotations;
+using Nancy.Swagger.Autofac.Demo.Modules;
+using Nancy.Swagger.Services;
+using Swagger.ObjectModel;
+
+namespace Nancy.Swagger.Autofac.Demo
+{
+    public class AutofacBootstrapper : AutofacNancyBootstrapper
+    {
+        public AutofacBootstrapper() : base()
+        {
+        }
+
+        protected override void ConfigureApplicationContainer(ILifetimeScope container)
+        {
+            SwaggerMetadataProvider.SetInfo("Nancy Swagger w/ AutoFac Example", "v0", "Our awesome service", new Contact()
+            {
+                EmailAddress = "exampleEmail@example.com"
+            });
+
+            SwaggerAnnotationsConfig.ShowOnlyAnnotatedRoutes = true;
+            this.ApplicationPipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Origin", "*"));
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/ModelDataProviders/AddressModelDataProvider.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/ModelDataProviders/AddressModelDataProvider.cs
@@ -1,0 +1,19 @@
+﻿using Nancy.Swagger.Autofac.Demo.Models;
+using Nancy.Swagger.Services;
+
+namespace Nancy.Swagger.Autofac.Demo.ModelDataProviders
+{
+    public class AddressModelDataProvider : ISwaggerModelDataProvider
+    {
+        public SwaggerModelData GetModelData()
+        {
+            return SwaggerModelData.ForType<Address>(with =>
+            {
+                with.Description("An address of a user");
+                with.Property(x => x.Address1)
+                    .Description("First Line of Address")
+                    .Required(true);
+            });
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/ModelDataProviders/RoleModelDataProvider.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/ModelDataProviders/RoleModelDataProvider.cs
@@ -1,0 +1,16 @@
+﻿using Nancy.Swagger.Autofac.Demo.Models;
+using Nancy.Swagger.Services;
+
+namespace Nancy.Swagger.Autofac.Demo.ModelDataProviders
+{
+    public class RoleModelDataProvider : ISwaggerModelDataProvider
+    {
+        public SwaggerModelData GetModelData()
+        {
+            return SwaggerModelData.ForType<Role>(with =>
+            {
+                with.Description("A role within the system");
+            });
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/ModelDataProviders/UserModelDataProvider.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/ModelDataProviders/UserModelDataProvider.cs
@@ -1,0 +1,24 @@
+﻿using Nancy.Swagger.Autofac.Demo.Models;
+using Nancy.Swagger.Services;
+
+namespace Nancy.Swagger.Autofac.Demo.ModelDataProviders
+{
+    public class UserModelDataProvider : ISwaggerModelDataProvider
+    {
+        public SwaggerModelData GetModelData()
+        {
+            return SwaggerModelData.ForType<User>(with =>
+            {
+                with.Description("A user of our awesome system!");
+                with.Property(x => x.Name)
+                    .Description("The user's name")
+                    .Required(true);
+                with.Property(x => x.Age)
+                    .Description("The user's age")
+                    .Required(true)
+                    .Minimum(1)
+                    .Maximum(100);
+            });
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/Models/Address.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/Models/Address.cs
@@ -1,0 +1,15 @@
+namespace Nancy.Swagger.Autofac.Demo.Models
+{
+    public class Address
+    {
+        public string Address1 { get; set; }
+
+        public string Address2 { get; set; }
+
+        public string Town { get; set; }
+
+        public string County { get; set; }
+
+        public string PostCode { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/Models/Role.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/Models/Role.cs
@@ -1,0 +1,11 @@
+namespace Nancy.Swagger.Autofac.Demo.Models
+{
+    public enum Role
+    {
+        User = 0,
+
+        Admin = 1,
+
+        God = 2
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/Models/ServiceDetails.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/Models/ServiceDetails.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Nancy.Swagger.Annotations.Attributes;
+
+namespace Nancy.Swagger.Autofac.Demo.Models
+{
+    [Model("The Details of this service")]
+    public class ServiceDetails
+    {
+        [ModelProperty(Description = "The name of the service", Required = true)]
+        public string Name { get; set; }
+
+        [ModelProperty(Description = "The id of the service", Required = true, Minimum = 1)]
+        public int ServiceNumber { get; set; }
+
+        [ModelProperty(Description = "The owner of the service")]
+        public ServiceOwner Owner { get; set; }
+
+        [ModelProperty(Description = "The customers of the service")]
+        public IList<ServiceCustomer> Customers { get; set; }
+
+    }
+
+    public class ServiceOwner
+    {
+        public string CompanyName { get; set; }
+        public string CompanyContactEmail { get; set; }
+        public string CompanyPhoneNumber { get; set; }
+    }
+
+    public class ServiceCustomer
+    {
+        public string CustomerName { get; set; }
+        public string CustomerEmail { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/Models/User.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/Models/User.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Nancy.Swagger.Autofac.Demo.Models
+{
+    public class User
+    {
+        [Required]
+        public string Name { get; set; }
+
+        [Range(1, 100)]
+        public int Age { get; set; }
+
+        public DateTime DateOfBirth { get; set; }
+
+        public Address Address { get; set; }
+
+        public Role Role { get; set; }
+
+        public IList<string> Tags { get; set; }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/Modules/HomeModule.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/Modules/HomeModule.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Nancy.ModelBinding;
+using Nancy.Swagger.Annotations.Attributes;
+using Nancy.Swagger.Autofac.Demo.Models;
+using Swagger.ObjectModel;
+
+namespace Nancy.Swagger.Autofac.Demo.Modules
+{
+    public class HomeModule : NancyModule
+    {
+        public HomeModule()
+        {
+            Head("/", _ => HttpStatusCode.OK, null, "Head");
+
+            Get("/", _ => GetPetStoreUrl(), null, "Home");
+
+            Get("/users", _ => GetUsers(), null, "GetUsers");
+
+            Post("/users", _ =>
+            {
+                var user = this.Bind<User>();
+                return PostUser(user);
+            });
+        }
+
+        private Response GetPetStoreUrl()
+        {
+            var port = Request.Url.Port ?? 80;
+            return Response.AsRedirect($"http://petstore.swagger.io/?url=http://localhost:{port}/api-docs");
+        }
+
+        [Route("Head")]
+        [Route(HttpMethod.Head, "/")]
+        [Route(Summary = "Example head method")]
+        [SwaggerResponse(HttpStatusCode.OK)]
+        private Response Head()
+        {
+            return HttpStatusCode.OK;
+        }
+
+        [Route("GetUsers")]
+        [Route(HttpMethod.Get, "/users")]
+        [Route(Summary = "Get All Users")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(IEnumerable<User>))]
+        [Route(Tags = new[] { "Users" })]
+        private IEnumerable<User> GetUsers()
+        {
+            return new[] {new User {Name = "Vincent Vega", Age = 45}};
+        }
+
+        [Route(HttpMethod.Post, "/users")]
+        [Route(Summary = "Post New User")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(User))]
+        [SwaggerResponse(HttpStatusCode.InternalServerError, Message = "Internal Server Error")]
+        [Route(Produces = new[] { "application/json" })]
+        [Route(Consumes = new[] { "application/json", "application/xml" })]
+        [Route(Tags = new[] { "Users" })]
+        private User PostUser([RouteParam(ParameterIn.Body)] User user)
+        {
+            return user;
+        } 
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/Modules/ServiceDetailsModule.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/Modules/ServiceDetailsModule.cs
@@ -1,0 +1,136 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using HttpMultipartParser;
+using Nancy.ModelBinding;
+using Nancy.Swagger.Annotations.Attributes;
+using Nancy.Swagger.Autofac.Demo.Models;
+using Nancy.Swagger.Services;
+using Swagger.ObjectModel;
+
+namespace Nancy.Swagger.Autofac.Demo.Modules
+{
+    public class ServiceDetailsModule : NancyModule
+    {
+        private const string ServiceTagName = "Service Details";
+        private const string ServiceTagDescription = "Operations for handling the service";
+
+        public ServiceDetailsModule(ISwaggerModelCatalog modelCatalog, ISwaggerTagCatalog tagCatalog) : base("/service")
+        {
+            modelCatalog.AddModel<ServiceOwner>();
+
+            tagCatalog.AddTag(new Tag()
+            {
+                Name = ServiceTagName,
+                Description = ServiceTagDescription
+            });
+
+            Get("/", _ => GetHome(), null, "ServiceHome");
+
+            Get("/details", _ => GetServiceDetails(), null, "GetDetails");
+
+            Get("/customers", _ => GetServiceCustomers(), null, "GetCustomers");
+
+            Get("/customers/{name}", parameters => GetServiceCustomer(parameters.name), null, "GetCustomer");
+
+            Post("/customer/{service}", parameters => PostServiceCustomer(parameters.service, this.Bind<ServiceCustomer>()), null, "PostNewCustomer");
+            
+            Post("/customer/{name}/file", parameters => PostCustomerReview(parameters.name, null), null, "PostCustomerReview");
+            
+        }
+
+
+        [Route("ServiceHome")]
+        [Route(HttpMethod.Get, "/")]
+        [Route(Summary = "Get Service Home")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK")]
+        [Route(Tags = new[] { ServiceTagName })]
+        private string GetHome()
+        {
+            return "Hello again, Swagger!";
+        }
+
+
+        [Route("GetDetails")]
+        [Route(HttpMethod.Get, "/details")]
+        [Route(Summary = "Get Service Details")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(ServiceDetails))]
+        [Route(Tags = new[] { ServiceTagName })]
+        private ServiceDetails GetServiceDetails()
+        {
+            return new ServiceDetails()
+            {
+                Name = "Nancy Swagger Service",
+                Owner = new ServiceOwner()
+                {
+                    CompanyName = "Swagger Example Inc.",
+                    CompanyContactEmail = "company@swaggerexample.inc"
+                },
+                Customers = new[]
+                {
+                    new ServiceCustomer() {CustomerName = "Jack"},
+                    new ServiceCustomer() {CustomerName = "Jill"}
+                }
+            };
+        }
+        
+        [Route("GetCustomers")]
+        [Route(HttpMethod.Get, "/customers")]
+        [Route(Summary = "Get Service Customers")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(IEnumerable<ServiceCustomer>))]
+        [Route(Tags = new[] { ServiceTagName })]
+        private ServiceCustomer[] GetServiceCustomers()
+        {
+            return new[]
+            {
+                new ServiceCustomer() {CustomerName = "Jack"},
+                new ServiceCustomer() {CustomerName = "Jill"}
+            };
+        }
+
+        [Route("GetCustomer")]
+        [Route(HttpMethod.Get, "/customers/{name}")]
+        [Route(Summary = "Get Service Customer")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(ServiceCustomer))]
+        [Route(Tags = new[] { ServiceTagName })]
+        private ServiceCustomer GetServiceCustomer([RouteParam(ParameterIn.Path, DefaultValue = "Jack")] string name)
+        {
+            return new ServiceCustomer() { CustomerName = name, CustomerEmail = name + "@my-service.com" };
+        }
+
+        [Route("PostNewCustomer")]
+        [Route(HttpMethod.Post, "/customer/{service}")]
+        [Route(Summary = "Post Service Customer")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(ServiceCustomer))]
+        [Route(Produces = new[] { "application/json" })]
+        [Route(Consumes = new[] { "application/json", "application/xml" })]
+        [Route(Tags = new[] { ServiceTagName })]
+        private ServiceCustomer PostServiceCustomer(
+            [RouteParam(ParameterIn.Path, DefaultValue = "my-service")] string service, 
+            [RouteParam(ParameterIn.Body)] ServiceCustomer customer)
+        {
+            return customer;
+        }
+
+        [Route("PostCustomerReview")]
+        [Route(HttpMethod.Post, "/customer/{name}/file")]
+        [Route(Summary = "Post Customer Review")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(SwaggerFile))]
+        [Route(Tags = new[] { ServiceTagName })]
+        [Route(Consumes = new[] { "multipart/form-data" })]
+        private string PostCustomerReview(
+            [RouteParam(ParameterIn.Path, DefaultValue = "Jill")] string name,
+            [RouteParam(ParameterIn.Form)] SwaggerFile file) //'file' is unused, but needed for the swagger doc
+        {
+
+            var parsed = new MultipartFormDataParser(Request.Body);
+            var uploadedFile = parsed.Files.FirstOrDefault()?.Data;
+            if (uploadedFile == null)
+            {
+                return "File Parsing Failed";
+            }
+            var reader = new StreamReader(uploadedFile);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/Nancy.Swagger.Autofac.Demo.xproj
+++ b/samples/Nancy.Swagger.Autofac.Demo/Nancy.Swagger.Autofac.Demo.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>e8adaf5d-37a6-4ffb-9f09-cf8fdd4ffa04</ProjectGuid>
+    <RootNamespace>Nancy.Swagger.Autofac.Demo</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/samples/Nancy.Swagger.Autofac.Demo/Program.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Nancy.Swagger.Autofac.Demo
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/Properties/AssemblyInfo.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Nancy.Swagger.Autofac.Demo")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e8adaf5d-37a6-4ffb-9f09-cf8fdd4ffa04")]

--- a/samples/Nancy.Swagger.Autofac.Demo/Properties/launchSettings.json
+++ b/samples/Nancy.Swagger.Autofac.Demo/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:50967/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Nancy.Swagger.Annotations.Demo": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/Startup.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/Startup.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Nancy.Owin;
+
+namespace Nancy.Swagger.Autofac.Demo
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            loggerFactory.AddConsole();
+
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseOwin(x => x.UseNancy(with => { with.Bootstrapper = new AutofacBootstrapper(); }));
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/TagProviders/UserTagProvider.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/TagProviders/UserTagProvider.cs
@@ -1,0 +1,19 @@
+﻿using Nancy.Swagger.Services;
+using Swagger.ObjectModel;
+
+namespace Nancy.Swagger.Autofac.Demo.TagProviders
+{
+
+
+    public class UserTagProvider : ISwaggerTagProvider
+    {
+        public Tag GetTag()
+        {
+            return new Tag()
+            {
+                Description = "Operations related to users",
+                Name = "Users"
+            };
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/project.json
+++ b/samples/Nancy.Swagger.Autofac.Demo/project.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+
+  "dependencies": {
+    "HttpMultipartParser": "2.1.7",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+    "Microsoft.AspNetCore.Hosting": "1.0.0",
+    "Microsoft.AspNetCore.Owin": "1.1.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
+    "Microsoft.Extensions.Logging.Console": "1.0.0",
+    "Nancy": "2.0.0-clinteastwood",
+    "Nancy.Bootstrappers.Autofac": "2.0.0-clinteastwood",
+    "Nancy.Swagger": "2.2.0-*",
+    "Nancy.Swagger.Annotations": "2.2.0-*"
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
+      },
+      "imports": "dnxcore50"
+    },
+    "net452": {
+      "frameworkAssemblies": {
+        "System.ComponentModel.DataAnnotations": "4.0.0.0"
+      }
+    }
+  }
+}

--- a/samples/Nancy.Swagger.Autofac.Demo/web.config
+++ b/samples/Nancy.Swagger.Autofac.Demo/web.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <!--
+    Configure your application settings in appsettings.json. Learn more at http://go.microsoft.com/fwlink/?LinkId=786380
+  -->
+
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <modules runAllManagedModulesForAllRequests="true" />
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+  </system.webServer>
+</configuration>

--- a/samples/Nancy.Swagger.Demo/project.json
+++ b/samples/Nancy.Swagger.Demo/project.json
@@ -5,7 +5,8 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
     "Microsoft.AspNetCore.Owin": "1.1.0",
-    "HttpMultipartParser":  "2.2.3",
+    "HttpMultipartParser": "2.2.3",
+    "Nancy": "2.0.0-clinteastwood",
     "Nancy.Swagger": {
       "target": "project"
     }
@@ -16,6 +17,15 @@
   },
 
   "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
+      },
+      "imports": "dnxcore50"
+    },
     "net452": {
       "frameworkAssemblies": {
         "System.ComponentModel.DataAnnotations": "4.0.0.0"

--- a/src/Nancy.Swagger.Annotations/SwaggerAnnotationsProvider.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerAnnotationsProvider.cs
@@ -12,24 +12,22 @@ namespace Nancy.Swagger.Annotations
 {
     public class SwaggerAnnotationsProvider : SwaggerMetadataProvider
     {
-        private NancyContext _context;
         private INancyModuleCatalog _moduleCatalog;
         private ISwaggerModelCatalog _modelCatalog;
         private ISwaggerTagCatalog _tagCatalog;
 
-        public SwaggerAnnotationsProvider(INancyModuleCatalog moduleCatalog, NancyContext context, ISwaggerModelCatalog modelCatalog, ISwaggerTagCatalog tagCatalog)
+        public SwaggerAnnotationsProvider(INancyModuleCatalog moduleCatalog, ISwaggerModelCatalog modelCatalog, ISwaggerTagCatalog tagCatalog)
         {
             _moduleCatalog = moduleCatalog;
-            _context = context;
             _modelCatalog = modelCatalog;
             _tagCatalog = tagCatalog;
         }
 
-        protected override IDictionary<string, SwaggerRouteData> RetrieveSwaggerPaths()
+        protected override IDictionary<string, SwaggerRouteData> RetrieveSwaggerPaths(NancyContext context)
         {
             var pathItems = new Dictionary<string, SwaggerRouteData>();
             foreach (var pair in _moduleCatalog
-                .GetAllModules(_context)
+                .GetAllModules(context)
                 .SelectMany(ToSwaggerRouteData))
             {
                 SwaggerRouteData entry;

--- a/src/Nancy.Swagger.Annotations/project.json
+++ b/src/Nancy.Swagger.Annotations/project.json
@@ -26,6 +26,7 @@
   },
 
   "dependencies": {
+    "Nancy": "2.0.0-clinteastwood",
     "Nancy.Swagger": {
       "target": "project"
     }
@@ -40,6 +41,15 @@
         "NETStandard.Library": "1.6.0",
         "System.Reflection": "4.1.0"
       }
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
+      },
+      "imports": "dnxcore50"
     }
   }
 }

--- a/src/Nancy.Swagger/Modules/SwaggerModule.cs
+++ b/src/Nancy.Swagger/Modules/SwaggerModule.cs
@@ -8,8 +8,8 @@ namespace Nancy.Swagger.Modules
         public SwaggerModule(ISwaggerMetadataProvider converter)
             : base(SwaggerConfig.ResourceListingPath)
         {
-            Get("/api-docs", _ => converter.GetSwaggerJson().ToJson());
-            Get("/swagger.json", _ => converter.GetSwaggerJson().ToJson());
+            Get("/api-docs", _ => converter.GetSwaggerJson(Context).ToJson());
+            Get("/swagger.json", _ => converter.GetSwaggerJson(Context).ToJson());
         }
     }
 }

--- a/src/Nancy.Swagger/Services/DefaultSwaggerMetadataProvider.cs
+++ b/src/Nancy.Swagger/Services/DefaultSwaggerMetadataProvider.cs
@@ -21,7 +21,7 @@ namespace Nancy.Swagger.Services
             this.tagCatalog = tagCatalog;
         }
 
-        protected override IDictionary<string, SwaggerRouteData> RetrieveSwaggerPaths()
+        protected override IDictionary<string, SwaggerRouteData> RetrieveSwaggerPaths(NancyContext context)
         {
             var pathItems = new Dictionary<string, SwaggerRouteData>();
             foreach (var routeDescription in this.routeCacheProvider.GetCache()

--- a/src/Nancy.Swagger/Services/ISwaggerMetadataProvider.cs
+++ b/src/Nancy.Swagger/Services/ISwaggerMetadataProvider.cs
@@ -5,6 +5,6 @@ namespace Nancy.Swagger.Services
     [SwaggerApi]
     public interface ISwaggerMetadataProvider
     {
-        SwaggerRoot GetSwaggerJson();
+        SwaggerRoot GetSwaggerJson(NancyContext context);
     }
 }

--- a/src/Nancy.Swagger/Services/SwaggerMetadataProvider.cs
+++ b/src/Nancy.Swagger/Services/SwaggerMetadataProvider.cs
@@ -54,11 +54,11 @@ namespace Nancy.Swagger.Services
             AddSecuritySchemeBuilder(builder, name);
         }
 
-        public SwaggerRoot GetSwaggerJson()
+        public SwaggerRoot GetSwaggerJson(NancyContext context)
         {
             var builder = new SwaggerRootBuilder();
 
-            foreach (var pathItem in this.RetrieveSwaggerPaths())
+            foreach (var pathItem in this.RetrieveSwaggerPaths(context))
             {
                 builder.Path(pathItem.Key, pathItem.Value.PathItem);
             }
@@ -92,7 +92,7 @@ namespace Nancy.Swagger.Services
             return builder.Build();
         }
 
-        protected abstract IDictionary<string, SwaggerRouteData> RetrieveSwaggerPaths();
+        protected abstract IDictionary<string, SwaggerRouteData> RetrieveSwaggerPaths(NancyContext context);
 
         protected abstract IList<SwaggerModelData> RetrieveSwaggerModels();
 

--- a/src/Nancy.Swagger/project.json
+++ b/src/Nancy.Swagger/project.json
@@ -39,6 +39,15 @@
       "imports": "dnxcore50",
       "NETStandard.Library": "1.6.0",
       "System.Reflection": "4.1.0"
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
+      },
+      "imports": "dnxcore50"
     }
   }
 }

--- a/src/Swagger.ObjectModel/project.json
+++ b/src/Swagger.ObjectModel/project.json
@@ -37,6 +37,16 @@
         "System.Dynamic.Runtime": "4.0.11",
         "System.Runtime.Serialization.Primitives": "4.1.1"
       }
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        },
+        "System.Runtime.Serialization.Primitives": "4.1.1"
+      },
+      "imports": "dnxcore50"
     }
   }
 


### PR DESCRIPTION
Hopefully this should resolve the issue presented in #67 .

TinyIoC can resolve instances for a class but it seems other DI frameworks might not support this. Normally this isn't an issue, except NancyContext is needed by SwaggerMetadataProvider.

This PR also adds support for .Net Core publishing which we apparently were not doing. Also fixes a bug where .Net Framework applications generate the proper swagger but .Net Core applications don't