### PR TITLE
Only describes parameters in functions that are specified

### DIFF
--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
@@ -45,7 +45,7 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
                 .ToDictionary(x => x.StatusCode.ToString(), y => (global::Swagger.ObjectModel.Response) y);
 
 
-            Parameters = handler.GetParameters()
+            Parameters = handler.GetParameters().Where(x => x.GetCustomAttributes<RouteParamAttribute>().Any())
                 .Select(CreateSwaggerParameterData)
                 .ToList();
 


### PR DESCRIPTION
Updates the swagger description to only include parameters that are actually annotated. 
#95 