### PR TITLE
Fix bug when using SecurityRequirement

### DIFF
--- a/src/Swagger.ObjectModel/SwaggerModel.cs
+++ b/src/Swagger.ObjectModel/SwaggerModel.cs
@@ -128,9 +128,9 @@ namespace Swagger.ObjectModel
                 var expando = new ExpandoObject();
                 var expandoCollection = (ICollection<KeyValuePair<string, object>>)expando;
 
-                foreach (string key in source.Keys)
+                foreach (var key in source.Keys)
                 {
-                    expandoCollection.Add(new KeyValuePair<string, object>(key, source[key]));
+                    expandoCollection.Add(new KeyValuePair<string, object>(key.ToString(), source[key]));
                 }
 
                 return expando;


### PR DESCRIPTION
When using the SecurityRequirement in MetadataModule , it will get the errors:
```
Nancy.RequestExecutionException: Oh noes! ---< System.InvalidCastException: Unable to cast object of type 'Swagger.ObjectModel.SecuritySchemes' to type 'System.String'.
   at Swagger.ObjectModel.SwaggerModel.SwaggerSerializerStrategy.ToObject(IDictionary source)
   at Swagger.ObjectModel.SwaggerModel.SwaggerSerializerStrategy.TrySerializeUnknownTypes(Object input, Object& output)
   at Swagger.ObjectModel.SimpleJson.SerializeValue(IJsonSerializerStrategy jsonSerializerStrategy, Object value, StringBuilder builder)
   at Swagger.ObjectModel.SimpleJson.SerializeObject(IJsonSerializerStrategy jsonSerializerStrategy, IEnumerable keys, IEnumerable values, StringBuilder builder)
...
```
Because the method `ToObject`  specify a string value which cause the `SecuritySchemes`  cast unsuccessfully!