### PR TITLE
Adds a default value for the appveyor build number

### DIFF
--- a/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
+++ b/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Provides Swagger data by annotating modules and routes.</Description>
+    <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>2.2.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <Authors>Kristian Hellang;Ciaran Downey;Contributors</Authors>
     <TargetFrameworks>net452;netstandard1.6;netcoreapp1.0</TargetFrameworks>

--- a/src/Nancy.Swagger/Nancy.Swagger.csproj
+++ b/src/Nancy.Swagger/Nancy.Swagger.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Generated API documentation for Nancy using Swagger.</Description>
+    <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>2.2.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <Authors>Kristian Hellang;Ciaran Downey;Contributors</Authors>
     <TargetFrameworks>net452;netstandard1.6;netcoreapp1.0</TargetFrameworks>

--- a/src/Swagger.ObjectModel/Swagger.ObjectModel.csproj
+++ b/src/Swagger.ObjectModel/Swagger.ObjectModel.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>A .NET object model for the Swagger spec.</Description>
+    <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>2.2.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <Authors>Kristian Hellang;Ciaran Downey;Contributors</Authors>
     <TargetFrameworks>net452;netstandard1.6;netcoreapp1.0</TargetFrameworks>


### PR DESCRIPTION
This fixes a problem where the solution would not build locally if there was no APPVEYOR_BUILD_NUMBER environment variable.