### PR TITLE
Fixes the alpha version for nuget dependencies

### DIFF
--- a/nugetPackageAll.bat
+++ b/nugetPackageAll.bat
@@ -1,5 +1,5 @@
 echo %APPVEYOR_BUILD_NUMBER%
 
-dotnet pack src/Nancy.Swagger --configuration Release --version-suffix "alpha"
-dotnet pack src/Nancy.Swagger.Annotations --configuration Release --version-suffix "alpha"
-dotnet pack src/Swagger.ObjectModel --configuration Release --version-suffix "alpha"
+dotnet pack src/Nancy.Swagger --configuration Release
+dotnet pack src/Nancy.Swagger.Annotations --configuration Release
+dotnet pack src/Swagger.ObjectModel --configuration Release

--- a/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
+++ b/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
@@ -4,6 +4,7 @@
     <Description>Provides Swagger data by annotating modules and routes.</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>2.2.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <Authors>Kristian Hellang;Ciaran Downey;Contributors</Authors>
     <TargetFrameworks>net452;netstandard1.6;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>Nancy.Swagger.Annotations</AssemblyName>

--- a/src/Nancy.Swagger/Nancy.Swagger.csproj
+++ b/src/Nancy.Swagger/Nancy.Swagger.csproj
@@ -4,6 +4,7 @@
     <Description>Generated API documentation for Nancy using Swagger.</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>2.2.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <Authors>Kristian Hellang;Ciaran Downey;Contributors</Authors>
     <TargetFrameworks>net452;netstandard1.6;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>Nancy.Swagger</AssemblyName>

--- a/src/Swagger.ObjectModel/Swagger.ObjectModel.csproj
+++ b/src/Swagger.ObjectModel/Swagger.ObjectModel.csproj
@@ -4,6 +4,7 @@
     <Description>A .NET object model for the Swagger spec.</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>2.2.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <Authors>Kristian Hellang;Ciaran Downey;Contributors</Authors>
     <TargetFrameworks>net452;netstandard1.6;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>Swagger.ObjectModel</AssemblyName>


### PR DESCRIPTION
This should fix the problems with Nancy.Swagger requiring 2.2.x instead of 2.2.x-alpha.

When this builds after merging, can you push the new version to NuGet?