### PR TITLE
support generic types, clean up redundant json output, support decimals

### DIFF
--- a/samples/Nancy.Swagger.Annotations.Demo/ModelDataProviders/GenericModelDataProvider.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/ModelDataProviders/GenericModelDataProvider.cs
@@ -1,0 +1,31 @@
+﻿using Nancy.Swagger.Demo.Models;
+using Nancy.Swagger.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nancy.Swagger.Demo.ModelDataProviders
+{
+    public class GenericModelDataProvider : ISwaggerModelDataProvider
+    {
+        public SwaggerModelData GetModelData()
+        {
+            return SwaggerModelData.ForType<ApiResponse<string>>(with =>
+            {
+                with.Description("An API response containing a string");
+            });
+        }
+    }
+
+    public class GenericModelDataProvider2 : ISwaggerModelDataProvider
+    {
+        public SwaggerModelData GetModelData()
+        {
+            return SwaggerModelData.ForType<ApiResponse<ApiResponse<string>>>(with =>
+            {
+                with.Description("An oddly double nested API response object");
+            });
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Models/ApiResponse.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Models/ApiResponse.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Nancy.Swagger.Demo.Models
+{
+    public class ApiResponse<T>
+    {
+        public List<string> Errors { get; set; }
+        public string Message { get; set; }
+        public T Data { get; set; }
+
+        public ApiResponse(T data)
+        {
+            Data = data;
+        }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Models/MultipleGenericResponse.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Models/MultipleGenericResponse.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nancy.Swagger.Demo.Models
+{
+    public class MultipleGenericResponse<T, U, V>
+    {
+        public List<string> Errors { get; set; }
+        public string Message { get; set; }
+        public T Data { get; set; }
+        public U Data2 { get; set; }
+        public V Data3 { get; set; }
+
+        public MultipleGenericResponse(T data, U data2, V data3)
+        {
+            Data = data;
+            Data2 = data2;
+            Data3 = data3;
+        }
+    }
+}
+

--- a/samples/Nancy.Swagger.Annotations.Demo/Modules/GenericModule.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Modules/GenericModule.cs
@@ -27,6 +27,34 @@ namespace Nancy.Swagger.Demo.Modules
                 var user = this.Bind<User>();
                 return PostUser(user);
             });
+
+            Get("/multi-generics", _ => GetMultipleGenerics(), null, "GetMultipleGenerics");
+            Get("/multi-nested-generics", _ => GetMultipleNestedGenerics(), null, "GetMultipleNestedGenerics");
+        }
+
+        [Route("GetMultipleGenerics")]
+        [Route(Summary = "Get a generic response with multiple types")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(MultipleGenericResponse<string, int, double>))]
+        [Route(Tags = new[] { "Generics" })]
+        private MultipleGenericResponse<string, int, double> GetMultipleGenerics()
+        {
+            return new MultipleGenericResponse<string, int, double>("A string!", 1, 42.5);
+        }
+
+        [Route("GetMultipleNestedGenerics")]
+        [Route(Summary = "Get crazy nested generic response")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(MultipleGenericResponse<ApiResponse<ApiResponse<string>>, MultipleGenericResponse<string, int, double>, long>))]
+        [Route(Tags = new[] { "Generics" })]
+        private MultipleGenericResponse<ApiResponse<ApiResponse<string>>, MultipleGenericResponse<string, int, double>, long> GetMultipleNestedGenerics()
+        {
+            // why would we do this to ourselves? BECAUSE WE CAN
+            return new MultipleGenericResponse<ApiResponse<ApiResponse<string>>, MultipleGenericResponse<string, int, double>, long>(
+                new ApiResponse<ApiResponse<string>>(
+                    new ApiResponse<string>("A string!")
+                ),
+                new MultipleGenericResponse<string, int, double>("A string!", 10, 1.35),
+                42
+            );
         }
 
         [Route("GetUsers")]

--- a/samples/Nancy.Swagger.Annotations.Demo/Modules/GenericModule.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Modules/GenericModule.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.FileProviders;
+using Nancy.ModelBinding;
+using Nancy.Responses.Negotiation;
+using Nancy.Swagger.Demo.Models;
+using Nancy.Swagger.Annotations.Attributes;
+using Swagger.ObjectModel;
+using Nancy.Swagger.Services;
+
+namespace Nancy.Swagger.Demo.Modules
+{
+    public class GenericModule : NancyModule
+    {
+        public GenericModule(ISwaggerTagCatalog tagCatalog)
+            : base("/generic")
+        {
+            tagCatalog.AddTag(new Tag()
+            {
+                Description = "All response are wrapped in a base class that can include metadata",
+                Name = "Generics"
+            });
+
+            Get("/users", _ => GetUsers(), null, "GetUsers");
+
+            Post("/users", _ =>
+            {
+                var user = this.Bind<User>();
+                return PostUser(user);
+            });
+        }
+
+        [Route("GetUsers")]
+        [Route(HttpMethod.Get, "/users")]
+        [Route(Summary = "Get All Users")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(ApiResponse<IEnumerable<User>>))]
+        [Route(Tags = new[] { "Generics" })]
+        private ApiResponse<IEnumerable<User>> GetUsers()
+        {
+            return new ApiResponse<IEnumerable<User>>(new[] {new User {Name = "Vincent Vega", Age = 45}});
+        }
+
+        [Route(HttpMethod.Post, "/users")]
+        [Route(Summary = "Post New User")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(ApiResponse<User>))]
+        [SwaggerResponse(HttpStatusCode.InternalServerError, Message = "Internal Server Error")]
+        [Route(Produces = new[] { "application/json" })]
+        [Route(Consumes = new[] { "application/json", "application/xml" })]
+        [Route(Tags = new[] { "Generics" })]
+        private ApiResponse<User> PostUser([RouteParam(ParameterIn.Body)] User user)
+        {
+            return new ApiResponse<User>(user);
+        } 
+    }
+}

--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
@@ -42,7 +42,7 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
 
             Responses = handler.GetCustomAttributes<SwaggerResponseAttribute>()
                 .Select(CreateSwaggerResponseObject)
-                .ToDictionary(x => x.StatusCode.ToString(), y => (global::Swagger.ObjectModel.Response) y);
+                .ToDictionary(x => x.GetStatusCode().ToString(), y => (global::Swagger.ObjectModel.Response) y);
 
 
             Parameters = handler.GetParameters().Where(x => x.GetCustomAttributes<RouteParamAttribute>().Any())

--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedResponse.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedResponse.cs
@@ -9,7 +9,8 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
 {
     public class AnnotatedResponse : global::Swagger.ObjectModel.Response
     {
-        public int StatusCode { get; set; }
+        private int StatusCode { get; set; }
+        public int GetStatusCode() => StatusCode;
 
         public AnnotatedResponse(SwaggerResponseAttribute attr, ISwaggerModelCatalog modelCatalog)
         {
@@ -18,7 +19,7 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
 
             if (attr.Model != null)
             {
-                Schema = SwaggerExtensions.GetSchema(modelCatalog, attr.Model);
+                Schema = SwaggerExtensions.GetSchema(modelCatalog, attr.Model, false);
             }
         }
     }

--- a/src/Nancy.Swagger/Services/RouteUtils/HttpResponseMetadata.cs
+++ b/src/Nancy.Swagger/Services/RouteUtils/HttpResponseMetadata.cs
@@ -21,7 +21,7 @@ namespace Nancy.Swagger.Services.RouteUtils
     {
         public override Schema GetSchema(ISwaggerModelCatalog modelCatalog)
         {
-            return SwaggerExtensions.GetSchema<T>(modelCatalog);
+            return SwaggerExtensions.GetSchema<T>(modelCatalog, false);
         }
     }
 }

--- a/src/Nancy.Swagger/Services/SwaggerMetadataProvider.cs
+++ b/src/Nancy.Swagger/Services/SwaggerMetadataProvider.cs
@@ -63,15 +63,15 @@ namespace Nancy.Swagger.Services
                 builder.Path(pathItem.Key, pathItem.Value.PathItem);
             }
 
-            //foreach (var model in this.RetrieveSwaggerModels())
-            //{
-            //    builder.Definition(model.ModelType.Name, model.);
-            //}
-
             builder.Info(_info);
             
             foreach (var model in RetrieveSwaggerModels())
             {
+                // arrays do not have to be defined in definitions, they are already being declared fully inline
+                // either they should use #ref or they shouldn't be in definitions
+                if (model.ModelType.IsContainer())
+                    continue;
+
                 builder.Definition(SwaggerConfig.ModelIdConvention(model.ModelType), model.GetSchema(true));
             }
 

--- a/src/Nancy.Swagger/Services/SwaggerMetadataProvider.cs
+++ b/src/Nancy.Swagger/Services/SwaggerMetadataProvider.cs
@@ -72,10 +72,7 @@ namespace Nancy.Swagger.Services
             
             foreach (var model in RetrieveSwaggerModels())
             {
-                Type t = GetType(model.ModelType);
-                String name = model.ModelType.Name;
-                if (t != model.ModelType) name = t.Name + "[]";
-                builder.Definition(name, model.GetSchema());
+                builder.Definition(SwaggerConfig.ModelIdConvention(model.ModelType), model.GetSchema(true));
             }
 
             foreach (var tag in RetrieveSwaggerTags())

--- a/src/Nancy.Swagger/SwaggerConfig.cs
+++ b/src/Nancy.Swagger/SwaggerConfig.cs
@@ -55,27 +55,15 @@ namespace Nancy.Swagger
         /// And so on.</remarks>
         public static string DefaultModelIdConvention(Type type)
         {
-            //var id = type.Name;
-            //var fullName = type.FullName;
-            //var idx = fullName.LastIndexOf('.');
-            //while (_resolvedModelIds.GetOrAdd(id, type) != type)
-            //{
-            //    idx = fullName.LastIndexOf('.', idx - 1);
-            //    id = idx <= 0 ? fullName : fullName.Substring(idx).Replace(".", "");
-            //}
-
-            //return id;
-
-
             if (type.IsContainer())
             {
-                return (type.GetElementType() ?? type.GetTypeInfo().GetGenericArguments().First()).Name + "[]";
+                return DefaultModelIdConvention(type.GetElementType() ?? type.GetTypeInfo().GetGenericArguments().First()) + "[]";
             }
 
             var typeInfo = type.GetTypeInfo();
             if (typeInfo.IsGenericType)
             {
-                // Format the generic type name to something like: GenericOfAgurment1AndArgument2
+                // Format the generic type name to something like: GenericOfArgument1AndArgument2
                 Type genericType = type.GetGenericTypeDefinition();
                 Type[] genericArguments = type.GetGenericArguments();
                 string genericTypeName = genericType.Name;
@@ -86,7 +74,16 @@ namespace Nancy.Swagger
                 return String.Format(CultureInfo.InvariantCulture, "{0}Of{1}", genericTypeName, String.Join("And", argumentTypeNames));
             }
 
-            return type.Name;
+            var id = type.Name;
+            var fullName = type.FullName;
+            var idx = fullName.LastIndexOf('.');
+            while (_resolvedModelIds.GetOrAdd(id, type) != type)
+            {
+                idx = fullName.LastIndexOf('.', idx - 1);
+                id = idx <= 0 ? fullName : fullName.Substring(idx).Replace(".", "");
+            }
+
+            return id;
         }
 
         /// <summary>

--- a/src/Nancy.Swagger/SwaggerConfig.cs
+++ b/src/Nancy.Swagger/SwaggerConfig.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using Swagger.ObjectModel;
+using System.Reflection;
+using System.Globalization;
+using System.Linq;
 
 namespace Nancy.Swagger
 {
@@ -52,16 +55,38 @@ namespace Nancy.Swagger
         /// And so on.</remarks>
         public static string DefaultModelIdConvention(Type type)
         {
-            var id = type.Name;
-            var fullName = type.FullName;
-            var idx = fullName.LastIndexOf('.');
-            while (_resolvedModelIds.GetOrAdd(id, type) != type)
+            //var id = type.Name;
+            //var fullName = type.FullName;
+            //var idx = fullName.LastIndexOf('.');
+            //while (_resolvedModelIds.GetOrAdd(id, type) != type)
+            //{
+            //    idx = fullName.LastIndexOf('.', idx - 1);
+            //    id = idx <= 0 ? fullName : fullName.Substring(idx).Replace(".", "");
+            //}
+
+            //return id;
+
+
+            if (type.IsContainer())
             {
-                idx = fullName.LastIndexOf('.', idx - 1);
-                id = idx <= 0 ? fullName : fullName.Substring(idx).Replace(".", "");
+                return (type.GetElementType() ?? type.GetTypeInfo().GetGenericArguments().First()).Name + "[]";
             }
 
-            return id;
+            var typeInfo = type.GetTypeInfo();
+            if (typeInfo.IsGenericType)
+            {
+                // Format the generic type name to something like: GenericOfAgurment1AndArgument2
+                Type genericType = type.GetGenericTypeDefinition();
+                Type[] genericArguments = type.GetGenericArguments();
+                string genericTypeName = genericType.Name;
+
+                // Trim the generic parameter counts from the name
+                genericTypeName = genericTypeName.Substring(0, genericTypeName.IndexOf('`'));
+                string[] argumentTypeNames = genericArguments.Select(t => DefaultModelIdConvention(t)).ToArray();
+                return String.Format(CultureInfo.InvariantCulture, "{0}Of{1}", genericTypeName, String.Join("And", argumentTypeNames));
+            }
+
+            return type.Name;
         }
 
         /// <summary>

--- a/src/Nancy.Swagger/SwaggerExtensions.cs
+++ b/src/Nancy.Swagger/SwaggerExtensions.cs
@@ -296,14 +296,14 @@ namespace Nancy.Swagger
         /// <returns></returns>
         public static ResponseBuilder Schema<T>(this ResponseBuilder responseBuilder, ISwaggerModelCatalog modelCatalog)
         {
-            var schema = GetSchema<T>(modelCatalog);
+            var schema = GetSchema<T>(modelCatalog, false);
             responseBuilder.Schema(schema);
             return responseBuilder;
         }
 
         public static OperationBuilder AddResponseSchema<T>(this OperationBuilder operationBuilder, ISwaggerModelCatalog modelCatalog)
         {
-            var schema = GetSchema<T>(modelCatalog);
+            var schema = GetSchema<T>(modelCatalog, false);
             operationBuilder.Response(r => r.Description("default").Schema(schema));
             return operationBuilder;
         }
@@ -315,17 +315,17 @@ namespace Nancy.Swagger
 
         public static BodyParameter AddBodySchema(this BodyParameter bodyParameter, Type type, ISwaggerModelCatalog modelCatalog)
         {
-            var schema = GetSchema(modelCatalog, type);
+            var schema = GetSchema(modelCatalog, type, false);
             bodyParameter.Schema = schema;
             return bodyParameter;
         }
 
-        public static Schema GetSchema<T>(ISwaggerModelCatalog modelCatalog)
+        public static Schema GetSchema<T>(ISwaggerModelCatalog modelCatalog, bool isDefinition)
         {
-            return GetSchema(modelCatalog, typeof(T));
+            return GetSchema(modelCatalog, typeof(T), isDefinition);
         }
 
-        public static Schema GetSchema(ISwaggerModelCatalog modelCatalog, Type t)
+        public static Schema GetSchema(ISwaggerModelCatalog modelCatalog, Type t, bool isDefinition)
         {
             if (SwaggerTypeMapping.IsMappedType(t))
             {
@@ -335,7 +335,7 @@ namespace Nancy.Swagger
             var schema = new Schema();
             if (model != null)
             {
-                schema = model.GetSchema();
+                schema = model.GetSchema(isDefinition);
             }
             else if (Primitive.IsPrimitive(t))
             {

--- a/src/Nancy.Swagger/SwaggerModelData.cs
+++ b/src/Nancy.Swagger/SwaggerModelData.cs
@@ -48,13 +48,13 @@ namespace Nancy.Swagger
                 });
         }
 
-        public Schema GetSchema()
+        public Schema GetSchema(bool isDefinition)
         {
             var sModel = this.ToModel(null, false).FirstOrDefault();
 
             if (sModel == null) return new Schema();
             
-            return sModel.CreateSchema(ModelType);
+            return sModel.CreateSchema(ModelType, isDefinition);
         }
     }
 }

--- a/src/Nancy.Swagger/SwaggerSchemaFactory.cs
+++ b/src/Nancy.Swagger/SwaggerSchemaFactory.cs
@@ -45,8 +45,6 @@ namespace Nancy.Swagger
                 {
                     Items.Type = "object";
                     Items.Ref = DefinitionsRefLocation + subType?.Name;
-
-                    Ref = DefinitionsRefLocation + subType?.Name + "[]";
                 }
             }
         }

--- a/src/Swagger.ObjectModel/Primitive.cs
+++ b/src/Swagger.ObjectModel/Primitive.cs
@@ -17,6 +17,7 @@ namespace Swagger.ObjectModel
             // Numbers
             { typeof(float), new Primitive("number", "float") },
             { typeof(double), new Primitive("number", "double") },
+            { typeof(decimal), new Primitive("number", "decimal") },
 
             // Boolean
             { typeof(bool), new Primitive("boolean") },

--- a/src/Swagger.ObjectModel/SwaggerModel.cs
+++ b/src/Swagger.ObjectModel/SwaggerModel.cs
@@ -105,7 +105,8 @@ namespace Swagger.ObjectModel
 
                 return ReflectionUtils.GetProperties(type)
                     .Where(x => x.CanRead)
-                    .Where(x => !ReflectionUtils.GetGetterMethodInfo(x).IsStatic)
+                    .Where(x => !ReflectionUtils.GetGetterMethodInfo(x).IsStatic
+                            && ReflectionUtils.GetGetterMethodInfo(x).IsPublic)
                     .ToDictionary(GetMemberName, ReflectionUtils.GetGetMethod);
             }
 


### PR DESCRIPTION
I'm using Nancy.Swagger for a corporate project, but ran into some issues before it would work for my use case. The things I changed:

1) Allow Generic types. It's a common practice to have every response wrapped in some generic response object that contains meta data, error explanations, etc. The existing problem is that if you had `ApiResponse<User>` and `ApiResponse<Service>`, they would both get the same definition id. I changed this so they would get `ApiResponseOfUser` and `ApiResponseOfService`.

2) Decimals weren't recognized as a primitive type, so `decimal?` wasn't properly recognized as a `decimal`. I added `decimal` alongside `int` and `double` as number types

3) The json had some cruft that I removed:
- Responses all had `StatusCode: xxx`, I removed this
- Response object schemas were fully detailed, rather than just supplying `$ref`
- Definitions redundantly had `$ref` specified on them