### PR TITLE
Handle nullable enum types

### DIFF
--- a/samples/Nancy.Swagger.Demo/Models/User.cs
+++ b/samples/Nancy.Swagger.Demo/Models/User.cs
@@ -16,7 +16,7 @@ namespace Nancy.Swagger.Demo.Models
 
         public Address Address { get; set; }
 
-        public Role Role { get; set; }
+        public Role? Role { get; set; }
 
         public IList<string> Tags { get; set; }
     }

--- a/src/Nancy.Swagger/SwaggerExtensions.cs
+++ b/src/Nancy.Swagger/SwaggerExtensions.cs
@@ -54,7 +54,7 @@ namespace Nancy.Swagger
 
                 return dataType;
             }
-            if (IsNullable(type))
+            if (type.IsNullable())
             {
                 type = Nullable.GetUnderlyingType(type);
             }
@@ -245,10 +245,10 @@ namespace Nancy.Swagger
 
         internal static bool IsImplicitlyRequired(this Type type)
         {
-            return type.GetTypeInfo().IsValueType && !IsNullable(type);
+            return type.GetTypeInfo().IsValueType && !type.IsNullable();
         }
 
-        internal static bool IsNullable(Type type)
+        internal static bool IsNullable(this Type type)
         {
             return type.GetTypeInfo().IsGenericType && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(Nullable<>);
         }

--- a/src/Nancy.Swagger/SwaggerExtensions.cs
+++ b/src/Nancy.Swagger/SwaggerExtensions.cs
@@ -54,6 +54,10 @@ namespace Nancy.Swagger
 
                 return dataType;
             }
+            if (IsNullable(type))
+            {
+                type = Nullable.GetUnderlyingType(type);
+            }
 
             if (type.IsContainer())
             {

--- a/src/Nancy.Swagger/SwaggerSchemaFactory.cs
+++ b/src/Nancy.Swagger/SwaggerSchemaFactory.cs
@@ -22,6 +22,10 @@ namespace Nancy.Swagger
             {
                 return new EnumSchema(t, sModel, isDefinition);
             }
+            if (SwaggerExtensions.IsNullable(t) && Nullable.GetUnderlyingType(t).GetTypeInfo().IsEnum)
+            {
+                return new EnumSchema(Nullable.GetUnderlyingType(t), sModel, isDefinition);
+            }
             return new ObjectSchema(t, sModel, isDefinition);
         }
 

--- a/src/Nancy.Swagger/SwaggerSchemaFactory.cs
+++ b/src/Nancy.Swagger/SwaggerSchemaFactory.cs
@@ -22,7 +22,7 @@ namespace Nancy.Swagger
             {
                 return new EnumSchema(t, sModel, isDefinition);
             }
-            if (SwaggerExtensions.IsNullable(t) && Nullable.GetUnderlyingType(t).GetTypeInfo().IsEnum)
+            if (t.IsNullable() && Nullable.GetUnderlyingType(t).GetTypeInfo().IsEnum)
             {
                 return new EnumSchema(Nullable.GetUnderlyingType(t), sModel, isDefinition);
             }


### PR DESCRIPTION
Nullable primitive types were being mapped correctly, but other value
types like Enums were not.
Make nullable types map to their underlying type, and generate the
schema for nullable Enums to be the same as the underlying Enum as well.