### PR TITLE
Starts Swagger/OpenAPI 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nancy plugin for generated API documentation in Swagger format.
 
-The Swagger specification (v2.0) can be found [here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
+The Swagger/OpenAPI specification (v3.0.0) can be found [here](https://swagger.io/specification/).
 
 ### Documentation
 
@@ -10,9 +10,13 @@ Documentation for Nancy.Swagger can be found in the [wiki pages](https://github.
 
 ### NuGet Packages
 
-Versions 2.2.0+ of this code uses Nancy v2 and is designed for .NET 4.5.2 and .NET Standard 1.6.
 
-Version 2.1.1 is designed for Nancy v1.4.3 on .Net 4.0+, and creates a Swagger 2.0 document.
+Version 3.* of this code uses Nancy v2 and generates a Swagger 3 (OpenAPI) document; (.NET 4.5.2, .NET Standard 1.6).
+ - This version is under development.
+
+Version 2.2.* of this code uses Nancy v2 and generates a Swagger 2 document; (.NET 4.5.2, .NET Standard 1.6).
+
+Version 2.1.1 is designed for Nancy v1.4.3 and creates a Swagger 2.0 document; (.NET 4.0).
 
 Version 0.* is designed for Nancy v1.4.3, but creates a Swagger 1.2 document.
  - If for some reason you need to make a change against this version of Nancy.Swagger, you can checkout the 1.4.3-stable branch.

--- a/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
+++ b/src/Nancy.Swagger.Annotations/Nancy.Swagger.Annotations.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides Swagger data by annotating modules and routes.</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
-    <VersionPrefix>2.2.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionPrefix>3.0.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <Authors>Kristian Hellang;Ciaran Downey;Contributors</Authors>
     <TargetFrameworks>net452;netstandard1.6;netcoreapp1.0</TargetFrameworks>

--- a/src/Nancy.Swagger/Nancy.Swagger.csproj
+++ b/src/Nancy.Swagger/Nancy.Swagger.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Generated API documentation for Nancy using Swagger.</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
-    <VersionPrefix>2.2.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionPrefix>3.0.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <Authors>Kristian Hellang;Ciaran Downey;Contributors</Authors>
     <TargetFrameworks>net452;netstandard1.6;netcoreapp1.0</TargetFrameworks>

--- a/src/Swagger.ObjectModel/Swagger.ObjectModel.csproj
+++ b/src/Swagger.ObjectModel/Swagger.ObjectModel.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A .NET object model for the Swagger spec.</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
-    <VersionPrefix>2.2.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionPrefix>3.0.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <Authors>Kristian Hellang;Ciaran Downey;Contributors</Authors>
     <TargetFrameworks>net452;netstandard1.6;netcoreapp1.0</TargetFrameworks>

--- a/src/Swagger.ObjectModel/SwaggerRoot.cs
+++ b/src/Swagger.ObjectModel/SwaggerRoot.cs
@@ -20,7 +20,7 @@ namespace Swagger.ObjectModel
         /// <summary>
         /// The swagger version.
         /// </summary>
-        private const string Version = "2.0";
+        private const string Version = "3.0.0";
 
         /// <summary>
         /// Specifies the Swagger Specification version being used.
@@ -29,8 +29,8 @@ namespace Swagger.ObjectModel
         /// <remarks>
         /// The value MUST be an existing Swagger specification version.
         /// </remarks>
-        [SwaggerProperty("swagger", true)]
-        public string SwaggerVersion
+        [SwaggerProperty("openapi", true)]
+        public string OpenAPIVersion
         {
             get
             {


### PR DESCRIPTION
I created a new branch called swagger-3 which can be used to capture our progress towards Swagger/OpenAPI 3. 

This change is very minimal - I created this PR just to bring attention to the new branch. 

Is AppVeyor going to push NuGet packages when the swagger-3 branch is merged into? We don't want to push any packages yet. 