### PR TITLE
Fix xunit warnings and add some tests

### DIFF
--- a/src/Swagger.ObjectModel/Builders/ApiKeySecuritySchemeBuilder.cs
+++ b/src/Swagger.ObjectModel/Builders/ApiKeySecuritySchemeBuilder.cs
@@ -33,7 +33,7 @@ namespace Swagger.ObjectModel.Builders
                 throw new RequiredFieldException("In");
             }
 
-            return new SecurityScheme { Type = SecuritySchemes.ApiKey, Name = this.name, In = this.securityIn };
+            return new SecurityScheme { Type = SecuritySchemes.ApiKey, Name = this.name, In = this.securityIn, Description = this.description };
         }
 
         /// <summary>

--- a/test/Swagger.ObjectModel.Tests/Builders/ApiKeySecuritySchemeBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/ApiKeySecuritySchemeBuilderTest.cs
@@ -1,0 +1,68 @@
+﻿using Swagger.ObjectModel.Builders;
+using Xunit;
+
+namespace Swagger.ObjectModel.Tests.Builders
+{
+    public class ApiKeySecuritySchemeBuilderTest
+    {
+        private ApiKeySecuritySchemeBuilder builder;
+        private string name = string.Empty;
+
+        public ApiKeySecuritySchemeBuilderTest()
+        {
+            this.builder = new ApiKeySecuritySchemeBuilder();
+            this.name = "name";
+        }
+
+        [Fact]
+        public void Should_ThrowRequiredFieldException_WhenNothingSet()
+        {
+            Assert.Throws<RequiredFieldException>(() => builder.Build());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Should_ThrowRequiredFieldException_WhenNameIsNullOrWhiteSpace(string name)
+        {
+            Assert.Throws<RequiredFieldException>(() => builder.Name(name).Build());
+        }
+
+        [Fact]
+        public void Should_AbleToSetNameAndApiKeyInHeader()
+        {
+            var securityScheme = builder.Name(name).IsInHeader().Build();
+
+            Assert.Equal(name, securityScheme.Name);
+            Assert.Equal(ApiKeyLocations.Header, securityScheme.In);
+        }
+
+        [Fact]
+        public void Should_AbleToSetNameAndApiKeyInQuery()
+        {
+            var securityScheme = builder.Name(name).IsInQuery().Build();
+
+            Assert.Equal(name, securityScheme.Name);
+            Assert.Equal(ApiKeyLocations.Query, securityScheme.In);
+        }
+
+        [Fact]
+        public void Should_BeApiKey_WhenBuildSuccess()
+        {
+            var securityScheme = builder.Name(name).IsInHeader().Build();
+
+            Assert.Equal(SecuritySchemes.ApiKey, securityScheme.Type);
+        }
+
+        [Fact]
+        public void Should_AbleToSetDescription()
+        {
+            string description = "desc";
+
+            var securityScheme = builder.Name(name).IsInHeader().Description(description).Build();
+
+            Assert.Equal(description, securityScheme.Description);
+        }
+
+    }
+}

--- a/test/Swagger.ObjectModel.Tests/Builders/BasicSecuritySchemeBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/BasicSecuritySchemeBuilderTest.cs
@@ -1,0 +1,33 @@
+﻿using Swagger.ObjectModel.Builders;
+using Xunit;
+
+namespace Swagger.ObjectModel.Tests.Builders
+{
+    public class BasicSecuritySchemeBuilderTest
+    {
+        private BasicSecuritySchemeBuilder builder;
+
+        public BasicSecuritySchemeBuilderTest()
+        {
+            this.builder = new BasicSecuritySchemeBuilder();
+        }
+
+        [Fact]
+        public void Type_ShouldBeBasic()
+        {
+            var securityScheme = builder.Build();
+
+            Assert.Equal(SecuritySchemes.Basic, securityScheme.Type);
+        }
+
+        [Fact]
+        public void Description_ShouldBeSettable()
+        {
+            string description = "desc";
+
+            var securityScheme = builder.Description(description).Build();
+
+            Assert.Equal(description, securityScheme.Description);
+        }
+    }
+}

--- a/test/Swagger.ObjectModel.Tests/Builders/BodyParameterBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/BodyParameterBuilderTest.cs
@@ -7,10 +7,10 @@ namespace Swagger.ObjectModel.Tests.Builders
     {
         private readonly BodyParameterBuilder builder;
         private readonly string name;
-        private readonly Schema schema; 
+        private readonly Schema schema;
 
         public BodyParameterBuilderTest()
-        {            
+        {
             this.builder = new BodyParameterBuilder();
 
             this.name = "name";
@@ -22,19 +22,19 @@ namespace Swagger.ObjectModel.Tests.Builders
 
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenNameOrSchemaIsNull()
-        {            
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Build());
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Name(name).Build());
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Name(string.Empty).Schema(schema).Build());
+        {
+            Assert.Throws<RequiredFieldException>(() => builder.Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Name(name).Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Name(string.Empty).Schema(schema).Build());
         }
 
         [Fact]
         public void Should_AbleToSetNameAndSchema()
-        {            
+        {
             var bodyParameter = builder.Name(name)
                                        .Schema(schema)
                                        .Build();
-         
+
             Assert.NotNull(bodyParameter);
             Assert.Equal(name, bodyParameter.Name);
             Assert.Same(schema, bodyParameter.Schema);
@@ -44,12 +44,12 @@ namespace Swagger.ObjectModel.Tests.Builders
         public void Should_AbleToSetDescription()
         {
             string description = "description";
-         
+
             var bodyParameter = builder.Name(name)
                                        .Schema(schema)
                                        .Description(description)
                                        .Build();
-            
+
             Assert.NotNull(bodyParameter);
             Assert.Equal(description, bodyParameter.Description);
         }

--- a/test/Swagger.ObjectModel.Tests/Builders/DataTypeBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/DataTypeBuilderTest.cs
@@ -1,6 +1,5 @@
-using System.Collections.Generic;
-using System.Linq;
 using Swagger.ObjectModel.Builders;
+using System.Linq;
 using Xunit;
 
 namespace Swagger.ObjectModel.Tests.Builders
@@ -32,14 +31,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.Maximum);
+            Assert.Null(result.Maximum);
         }
 
         [Fact]
         public void Maximum_ShouldBeSettable()
-        {            
+        {
             var maxValue = int.MaxValue;
-        
+
             var result = builder.Maximum(maxValue).Build();
 
             Assert.NotNull(result);
@@ -52,14 +51,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.Minimum);
+            Assert.Null(result.Minimum);
         }
 
         [Fact]
         public void Minimum_ShouldBeSettable()
-        {            
+        {
             var minValue = int.MinValue;
-        
+
             var result = builder.Minimum(minValue).Build();
 
             Assert.NotNull(result);
@@ -72,14 +71,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.Type);
+            Assert.Null(result.Type);
         }
 
         [Fact]
         public void Type_ShouldBeSettable()
-        {            
+        {
             var type = "int";
-        
+
             var result = builder.Type(type).Build();
 
             Assert.NotNull(result);
@@ -92,7 +91,7 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.CollectionFormat);
+            Assert.Null(result.CollectionFormat);
         }
 
         [Fact]
@@ -112,14 +111,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.Default);
+            Assert.Null(result.Default);
         }
 
         [Fact]
         public void Default_ShouldBeSettable()
         {
             var obj = new object();
-            
+
             var result = builder.Default(obj).Build();
 
             Assert.NotNull(result);
@@ -132,14 +131,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.Enum);
+            Assert.Null(result.Enum);
         }
 
         [Fact]
         public void Enum_ShouldBeSettable()
         {
             var enumValue = "enum";
-            
+
             var result = builder.Enum(enumValue).Build();
 
             Assert.NotNull(result);
@@ -152,7 +151,7 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.ExclusiveMaximum);
+            Assert.Null(result.ExclusiveMaximum);
         }
 
         [Fact]
@@ -161,7 +160,7 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.IsExclusiveMaximum().Build();
 
             Assert.NotNull(result);
-            Assert.Equal(true, result.ExclusiveMaximum);
+            Assert.True(result.ExclusiveMaximum);
         }
 
         [Fact]
@@ -170,7 +169,7 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.ExclusiveMinimum);
+            Assert.Null(result.ExclusiveMinimum);
         }
 
         [Fact]
@@ -179,7 +178,7 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.IsExclusiveMinimum().Build();
 
             Assert.NotNull(result);
-            Assert.Equal(true, result.ExclusiveMinimum);
+            Assert.True(result.ExclusiveMinimum);
         }
 
         [Fact]
@@ -188,14 +187,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.Format);
+            Assert.Null(result.Format);
         }
 
         [Fact]
         public void Format_ShouldBeSettable()
         {
             var format = "mm-dd-yyyy";
-            
+
             var result = builder.Format(format).Build();
 
             Assert.NotNull(result);
@@ -208,14 +207,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.Items);
+            Assert.Null(result.Items);
         }
 
         [Fact]
         public void Items_ShouldBeSettable()
         {
             var item = new Item();
-            
+
             var result = builder.Items(item).Build();
 
             Assert.NotNull(result);
@@ -228,14 +227,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.MaxItems);
+            Assert.Null(result.MaxItems);
         }
 
         [Fact]
         public void MaxItems_ShouldBeSettable()
         {
             var maxItems = 2;
-            
+
             var result = builder.MaxItems(maxItems).Build();
 
             Assert.NotNull(result);
@@ -248,14 +247,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.MaxLength);
+            Assert.Null(result.MaxLength);
         }
 
         [Fact]
         public void MaxLength_ShouldBeSettable()
         {
             var maxLength = 2;
-            
+
             var result = builder.MaxLength(maxLength).Build();
 
             Assert.NotNull(result);
@@ -268,14 +267,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.MinItems);
+            Assert.Null(result.MinItems);
         }
 
         [Fact]
         public void MinItems_ShouldBeSettable()
         {
             var minItems = 2;
-            
+
             var result = builder.MinItems(minItems).Build();
 
             Assert.NotNull(result);
@@ -288,14 +287,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.MultipleOf);
+            Assert.Null(result.MultipleOf);
         }
 
         [Fact]
         public void MultipleOf_ShouldBeSettable()
         {
             var multipleOf = 2;
-            
+
             var result = builder.MultipleOf(multipleOf).Build();
 
             Assert.NotNull(result);
@@ -308,14 +307,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.Pattern);
+            Assert.Null(result.Pattern);
         }
 
         [Fact]
         public void Pattern_ShouldBeSettable()
         {
             var pattern = "mm-dd-yyyy";
-            
+
             var result = builder.Pattern(pattern).Build();
 
             Assert.NotNull(result);
@@ -328,14 +327,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.Ref);
+            Assert.Null(result.Ref);
         }
 
         [Fact]
         public void Reference_ShouldBeSettable()
         {
             var reference = "#ref";
-            
+
             var result = builder.Reference(reference).Build();
 
             Assert.NotNull(result);
@@ -348,16 +347,16 @@ namespace Swagger.ObjectModel.Tests.Builders
             var result = builder.Build();
 
             Assert.NotNull(result);
-            Assert.Equal(null, result.UniqueItems);
+            Assert.Null(result.UniqueItems);
         }
 
         [Fact]
         public void UniqueItems_ShouldBeSettable()
-        {            
+        {
             var result = builder.IsUniqueItems().Build();
 
             Assert.NotNull(result);
-            Assert.Equal(true, result.UniqueItems);
+            Assert.True(result.UniqueItems);
         }
     }
 }

--- a/test/Swagger.ObjectModel.Tests/Builders/ExternalDocumentationBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/ExternalDocumentationBuilderTest.cs
@@ -16,32 +16,32 @@ namespace Swagger.ObjectModel.Tests.Builders
 
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenUrlIsNullOrEmpty()
-        {                           
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Url("").Build());
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Url(null).Build());            
+        {
+            Assert.Throws<RequiredFieldException>(() => builder.Url("").Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Url(null).Build());
         }
 
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenUrlIsNotSet()
-        {         
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Build());
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Description("desc").Build());            
+        {
+            Assert.Throws<RequiredFieldException>(() => builder.Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Description("desc").Build());
         }
 
         [Fact]
         public void Should_AbleToSetUrl()
-        {            
+        {
             var externalDocumentation = builder.Url(url).Build();
-         
+
             Assert.NotNull(externalDocumentation);
             Assert.Equal(url, externalDocumentation.Url);
         }
 
         [Fact]
         public void Should_AbleToSetDescription()
-        {            
+        {
             string description = "description";
-         
+
             var externalDocumentation = builder.Url(url)
                                                .Description(description)
                                                .Build();

--- a/test/Swagger.ObjectModel.Tests/Builders/InfoBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/InfoBuilderTest.cs
@@ -14,21 +14,21 @@ namespace Swagger.ObjectModel.Tests.Builders
         [InlineData("title", null)]
         public void Should_ThrowRequiredFieldException_WhenTitleOrVersionIsEmptyOrWhiteSpace(string title, string version)
         {
-            Assert.Throws(typeof(RequiredFieldException), () => new InfoBuilder(title, version).Build());
+            Assert.Throws<RequiredFieldException>(() => new InfoBuilder(title, version).Build());
         }
 
         [Theory]
-        [InlineData("title", "1.0","description")]
+        [InlineData("title", "1.0", "description")]
         [InlineData("title", "1.0", "")]
-        public void Should_AbleToSetDescription(string title, string version,string descrption)
+        public void Should_AbleToSetDescription(string title, string version, string descrption)
         {
             var info = new InfoBuilder(title, version).Description(descrption).Build();
 
             Assert.Equal(title, info.Title);
             Assert.Equal(version, info.Version);
-            Assert.Equal(descrption, info.Description);         
+            Assert.Equal(descrption, info.Description);
         }
-       
+
         [Theory]
         [InlineData("title", "1.0", "terms of service")]
         [InlineData("title", "1.0", "")]

--- a/test/Swagger.ObjectModel.Tests/Builders/LicenseBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/LicenseBuilderTest.cs
@@ -4,13 +4,13 @@ using Xunit;
 namespace Swagger.ObjectModel.Tests.Builders
 {
     public class LicenseBuilderTest
-    {                     
+    {
         [Theory]
-        [InlineData("")]        
+        [InlineData("")]
         [InlineData(null)]
         public void Should_ThrowRequiredFieldException_When_NameIsNullOrWhiteSpace(string name)
-        {            
-            Assert.Throws(typeof(RequiredFieldException), () => new LicenseBuilder(name).Build());
+        {
+            Assert.Throws<RequiredFieldException>(() => new LicenseBuilder(name).Build());
         }
 
         [Theory]
@@ -22,6 +22,6 @@ namespace Swagger.ObjectModel.Tests.Builders
             var license = new LicenseBuilder(name).Url(url).Build();
 
             Assert.Equal(url, license.Url);
-        }        
+        }
     }
 }

--- a/test/Swagger.ObjectModel.Tests/Builders/OperationBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/OperationBuilderTest.cs
@@ -24,9 +24,9 @@ namespace Swagger.ObjectModel.Tests.Builders
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenResponsesIsNotSet()
         {
-            Assert.Throws(typeof(RequiredFieldException), () => new OperationBuilder().Build());
+            Assert.Throws<RequiredFieldException>(() => new OperationBuilder().Build());
         }
-      
+
         [Fact]
         public void Should_AbleToSetResponseWithStringAndAction()
         {
@@ -158,7 +158,7 @@ namespace Swagger.ObjectModel.Tests.Builders
             var operation = GetBasicBuilderWithResponse().ConsumeMimeType(mimeType).Build();
 
             Assert.NotNull(operation.Consumes);
-            Assert.True(operation.Consumes.Contains(mimeType));
+            Assert.Contains(mimeType, operation.Consumes);
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace Swagger.ObjectModel.Tests.Builders
             var operation = GetBasicBuilderWithResponse().ProduceMimeType(mimeType).Build();
 
             Assert.NotNull(operation.Produces);
-            Assert.True(operation.Produces.Contains(mimeType));
+            Assert.Contains(mimeType, operation.Produces);
         }
 
         [Fact]
@@ -202,7 +202,7 @@ namespace Swagger.ObjectModel.Tests.Builders
             var operation = GetBasicBuilderWithResponse().Parameter(parameter).Build();
 
             Assert.NotNull(operation.Parameters);
-            Assert.True(operation.Parameters.Contains(parameter));
+            Assert.Contains(parameter, operation.Parameters);
         }
 
         [Fact]
@@ -236,7 +236,7 @@ namespace Swagger.ObjectModel.Tests.Builders
                                     .BodyParameter(x => x.Name("name").Schema(new Schema()))
                                     .Build();
 
-            Assert.NotNull(operation.Parameters);            
+            Assert.NotNull(operation.Parameters);
         }
 
         [Fact]
@@ -245,14 +245,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var operation = GetBasicBuilderWithResponse().Scheme(Schemes.Http).Build();
 
             Assert.NotNull(operation.Schemes);
-            Assert.True(operation.Schemes.Contains(Schemes.Http));
+            Assert.Contains(Schemes.Http, operation.Schemes);
         }
 
         [Fact]
         public void Should_AbleToSetIsDeprecated()
         {
             var operation = GetBasicBuilderWithResponse().IsDeprecated().Build();
-            
+
             Assert.True(operation.Deprecated);
         }
 
@@ -260,7 +260,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         public void Should_AbleToSetSecurityRequirementWithKeyValuePair()
         {
             var security = new KeyValuePair<SecuritySchemes, IEnumerable<string>>(SecuritySchemes.ApiKey, new List<string> { "string" });
-                       
+
             var operation = GetBasicBuilderWithResponse().SecurityRequirement(security).Build();
 
             Assert.NotNull(operation.SecurityRequirements);

--- a/test/Swagger.ObjectModel.Tests/Builders/ParameterBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/ParameterBuilderTest.cs
@@ -12,26 +12,26 @@ namespace Swagger.ObjectModel.Tests.Builders
         public ParameterBuilderTest()
         {
             this.builder = new ParameterBuilder();
-            this.name= "name";
+            this.name = "name";
         }
 
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenNameIsNotSet()
         {
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Build());         
+            Assert.Throws<RequiredFieldException>(() => builder.Build());
         }
 
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenNameIsNullOrWhiteSpace()
-        {            
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Name("").Build());
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Name(null).Build());
+        {
+            Assert.Throws<RequiredFieldException>(() => builder.Name("").Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Name(null).Build());
         }
 
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenParameterInIsNotSet()
         {
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Name(name).Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Name(name).Build());
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         {
             var parameter = builder.Name(name).In(ParameterIn.Path).Build();
 
-            Assert.Equal(true, parameter.Required);
+            Assert.True(parameter.Required);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         {
             var parameter = builder.Name(name).In(ParameterIn.Query).IsRequired().Build();
 
-            Assert.Equal(true, parameter.Required);
+            Assert.True(parameter.Required);
         }
 
         [Theory]
@@ -58,13 +58,13 @@ namespace Swagger.ObjectModel.Tests.Builders
         {
             var parameter = builder.Name(name).In(parameterIn).Build();
 
-            Assert.Equal(false, parameter.Required.HasValue);
+            Assert.False(parameter.Required.HasValue);
         }
 
         [Fact]
         public void Should_ThrowInvalidOperationException_WhenParameterInIsBody()
         {
-            Assert.Throws(typeof(InvalidOperationException), () => builder.Name(name).In(ParameterIn.Body).Build());
+            Assert.Throws<InvalidOperationException>(() => builder.Name(name).In(ParameterIn.Body).Build());
         }
 
         [Fact]

--- a/test/Swagger.ObjectModel.Tests/Builders/PathItemBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/PathItemBuilderTest.cs
@@ -13,17 +13,17 @@ namespace Swagger.ObjectModel.Tests.Builders
             var operationBuilder = new OperationBuilder().Response(r => r.Description("N/A"));
 
             var pathItem = new PathItemBuilder(HttpMethod.Get).Operation(operationBuilder).Build();
-                        
+
             Assert.Equal(operationBuilder.Build().Responses, pathItem.Get.Responses);
         }
 
         [Fact]
         public void Should_AbleToSetOperationWithAction()
-        {            
+        {
             var pathItem = new PathItemBuilder(HttpMethod.Get)
                                     .Operation(x => x.Response(r => r.Description("N/A")))
                                     .Build();
-            
+
             Assert.Equal("N/A", pathItem.Get.Responses["default"].Description);
         }
 
@@ -36,7 +36,7 @@ namespace Swagger.ObjectModel.Tests.Builders
                                     .Parameter(parameter)
                                     .Build();
 
-            Assert.Equal(1, pathItem.Parameters.Count());
+            Assert.Single(pathItem.Parameters);
             Assert.Equal(parameter, pathItem.Parameters.FirstOrDefault());
         }
 
@@ -49,7 +49,7 @@ namespace Swagger.ObjectModel.Tests.Builders
                                     .Parameter(pBuilder)
                                     .Build();
 
-            Assert.Equal(1, pathItem.Parameters.Count());
+            Assert.Single(pathItem.Parameters);
             Assert.Equal(pBuilder.Build().Name, pathItem.Parameters.FirstOrDefault().Name);
             Assert.Equal(pBuilder.Build().In, pathItem.Parameters.FirstOrDefault().In);
         }
@@ -58,7 +58,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         public void Should_AbleToSetMultiParameters()
         {
             var parameters = new List<Parameter>();
-            parameters.Add(new Parameter { Name = "first parameter"  });
+            parameters.Add(new Parameter { Name = "first parameter" });
             parameters.Add(new Parameter { Name = "second parameter" });
 
             var pathItem = new PathItemBuilder(HttpMethod.Get)
@@ -73,7 +73,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         public void Should_SetOpeationToGet_WhenHttpMethodIsGet()
         {
             var pathItem = new PathItemBuilder(HttpMethod.Get).Build();
-            
+
             Assert.NotNull(pathItem.Get);
             Assert.Null(pathItem.Post);
             Assert.Null(pathItem.Put);
@@ -87,7 +87,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         public void Should_SetOpeationToPost_WhenHttpMethodIsPost()
         {
             var pathItem = new PathItemBuilder(HttpMethod.Post).Build();
-            
+
             Assert.NotNull(pathItem.Post);
             Assert.Null(pathItem.Get);
             Assert.Null(pathItem.Put);

--- a/test/Swagger.ObjectModel.Tests/Builders/ResponseBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/ResponseBuilderTest.cs
@@ -17,14 +17,14 @@ namespace Swagger.ObjectModel.Tests.Builders
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenDescriptionIsNotSet()
         {
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Build());
         }
 
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenDescriptionIsNullOrWhiteSpace()
         {
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Description("").Build());
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Description(null).Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Description("").Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Description(null).Build());
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace Swagger.ObjectModel.Tests.Builders
                                 .Schema<int>()
                                 .Build();
 
-            Assert.Equal(new SchemaBuilder<int>().Build().Type, response.Schema.Type);            
+            Assert.Equal(new SchemaBuilder<int>().Build().Type, response.Schema.Type);
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace Swagger.ObjectModel.Tests.Builders
                                   .Build();
 
             Assert.Equal(1, response.Headers.Count);
-            Assert.Equal(hBuilder.Build().Default,response.Headers[headerName].Default);
+            Assert.Equal(hBuilder.Build().Default, response.Headers[headerName].Default);
         }
 
         [Fact]

--- a/test/Swagger.ObjectModel.Tests/Builders/SchemaBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/SchemaBuilderTest.cs
@@ -1,0 +1,82 @@
+﻿using Swagger.ObjectModel.Builders;
+using Xunit;
+
+namespace Swagger.ObjectModel.Tests.Builders
+{
+    public class SchemaBuilderTest
+    {
+        private SchemaBuilder<int> GetInt32SchemaBuilder()
+        {
+            return new SchemaBuilder<int>();
+        }
+
+        private SchemaBuilder<string> GetStringSchemaBuilder()
+        {
+            return new SchemaBuilder<string>();
+        }
+
+        [Fact]
+        public void Type_ShouldDefaultToInt32()
+        {
+            var result = GetInt32SchemaBuilder().Build();
+
+            Assert.Equal("Int32", result.Type);
+        }
+
+        [Fact]
+        public void Type_ShouldDefaultToString()
+        {
+            var result = GetStringSchemaBuilder().Build();
+
+            Assert.Equal("String", result.Type);
+        }
+
+        [Fact]
+        public void Ref_ShouldDefaultToNull()
+        {
+            var result = GetInt32SchemaBuilder().Build();
+
+            Assert.Null(result.Ref);
+        }
+
+        [Fact]
+        public void Discriminator_ShouldBeSettable()
+        {
+            string discriminator = "discriminator";
+
+            var result = GetInt32SchemaBuilder().Discriminator(discriminator).Build();
+
+            Assert.Equal(discriminator, result.Discriminator);
+        }
+
+        [Fact]
+        public void ExternalDocumentation_ShouldBeSettable()
+        {
+            var externalDocumentation = new ExternalDocumentation() { Url = "url" };
+
+            var result = GetInt32SchemaBuilder().ExternalDocumentation(externalDocumentation).Build();
+
+            Assert.Equal(externalDocumentation.Url, result.ExternalDocumentation.Url);
+        }
+
+        [Fact]
+        public void ExternalDocumentationWithBuilder_ShouldBeSettable()
+        {
+            var exBuilder = new ExternalDocumentationBuilder().Url("url");
+
+            var result = GetInt32SchemaBuilder().ExternalDocumentation(exBuilder).Build();
+
+            Assert.Equal(exBuilder.Build().Url, result.ExternalDocumentation.Url);
+        }
+
+        [Fact]
+        public void Example_ShouldBeSettable()
+        {
+            object example = new object();
+
+            var result = GetInt32SchemaBuilder().Example(example).Build();
+
+            Assert.Equal(example, result.Example);
+        }
+    }
+}

--- a/test/Swagger.ObjectModel.Tests/Builders/SecurityRequirementBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/SecurityRequirementBuilderTest.cs
@@ -15,7 +15,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenSchemeIsNotSet()
         {
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Build());
         }
 
         [Theory]
@@ -25,9 +25,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         public void Should_AbleToSetSecurityScheme(SecuritySchemes schemes)
         {
             var result = builder.SecurityScheme(schemes).Build();
-
-            Assert.NotNull(result);
-            Assert.Equal(schemes, result.Key);            
+            Assert.Equal(schemes, result.Key);
         }
 
         [Theory]
@@ -38,8 +36,6 @@ namespace Swagger.ObjectModel.Tests.Builders
             string scopeName = "scopeName";
 
             var result = builder.SecurityScheme(schemes).SecurityScheme(scopeName).Build();
-
-            Assert.NotNull(result);
             Assert.Empty(result.Value);
         }
 
@@ -50,9 +46,7 @@ namespace Swagger.ObjectModel.Tests.Builders
 
             var result = builder.SecurityScheme(SecuritySchemes.Oauth2).SecurityScheme(scopeName).Build();
 
-            Assert.NotNull(result);
             Assert.NotEmpty(result.Value);
         }
-
     }
 }

--- a/test/Swagger.ObjectModel.Tests/Builders/SwaggerRootBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/SwaggerRootBuilderTest.cs
@@ -24,7 +24,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         [Fact]
         public void Should_ThrowRequiredFieldException_WhenNotSetAnythings()
         {
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Build());
         }
 
         [Fact]
@@ -32,20 +32,20 @@ namespace Swagger.ObjectModel.Tests.Builders
         {
             Info info = null;
 
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Info(info).Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Info(info).Build());
         }
 
         [Fact]
         public void Should_AbleToSetInfo()
         {
-            var info = new Info { Version="1.0" };
+            var info = new Info { Version = "1.0" };
             var pathItem = new PathItem { Get = new Operation() };
 
             var swaggerRoot = builder.Info(info)
-                                     .Path("/endpoint",pathItem)
+                                     .Path("/endpoint", pathItem)
                                      .Build();
 
-            Assert.Equal(info,swaggerRoot.Info);            
+            Assert.Equal(info, swaggerRoot.Info);
         }
 
         [Fact]
@@ -57,9 +57,9 @@ namespace Swagger.ObjectModel.Tests.Builders
             var swaggerRoot = builder.Info(info)
                                      .Path("/endpoint", pathItem)
                                      .Build();
-            
+
             Assert.True(swaggerRoot.Paths.Keys.Contains("/endpoint"));
-            Assert.Equal(pathItem ,swaggerRoot.Paths["/endpoint"]);
+            Assert.Equal(pathItem, swaggerRoot.Paths["/endpoint"]);
         }
 
         [Fact]
@@ -71,14 +71,14 @@ namespace Swagger.ObjectModel.Tests.Builders
             var swaggerRoot = builder.Info(info)
                                      .Path("/endpoint", pathItem)
                                      .Build();
-            
+
             Assert.Equal(pathItem.Build().Get, swaggerRoot.Paths["/endpoint"].Get);
         }
 
         [Fact]
         public void Should_AbleToSetPathWithEndPointName()
         {
-            var info = new Info { Version = "1.0" };            
+            var info = new Info { Version = "1.0" };
 
             var swaggerRoot = builder.Info(info)
                                      .Path("/endpoint")
@@ -97,7 +97,7 @@ namespace Swagger.ObjectModel.Tests.Builders
                                      .Path("endpoint", pathItem)
                                      .Build();
 
-            Assert.True(swaggerRoot.Paths.Keys.Contains("/endpoint"));            
+            Assert.True(swaggerRoot.Paths.Keys.Contains("/endpoint"));
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace Swagger.ObjectModel.Tests.Builders
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().Host(host).Build();
 
-            Assert.Equal(host,swaggerRoot.Host);
+            Assert.Equal(host, swaggerRoot.Host);
         }
 
         [Fact]
@@ -127,15 +127,15 @@ namespace Swagger.ObjectModel.Tests.Builders
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().BasePath(basePath).Build();
 
-            Assert.Equal(string.Concat("/",basePath), swaggerRoot.BasePath);
+            Assert.Equal(string.Concat("/", basePath), swaggerRoot.BasePath);
         }
 
         [Fact]
         public void Should_AbleToSetScheme()
-        {            
+        {
             var swaggerRoot = GetBasicSwaggerRootBuilder().Scheme(Schemes.Http).Build();
 
-            Assert.True(swaggerRoot.Schemes.Contains(Schemes.Http));
+            Assert.Contains(Schemes.Http, swaggerRoot.Schemes);
         }
 
         [Fact]
@@ -145,17 +145,17 @@ namespace Swagger.ObjectModel.Tests.Builders
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().ConsumeMimeType(mimeType).Build();
 
-            Assert.True(swaggerRoot.Consumes.Contains(mimeType));
+            Assert.Contains(mimeType, swaggerRoot.Consumes);
         }
 
         [Fact]
         public void Should_AbleToSetConsumeMimeTypes()
         {
-            var mimeTypes = new List<string>() { "application/json" , "application/xml" };
+            var mimeTypes = new List<string>() { "application/json", "application/xml" };
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().ConsumeMimeTypes(mimeTypes).Build();
 
-            Assert.Equal(mimeTypes,swaggerRoot.Consumes);
+            Assert.Equal(mimeTypes, swaggerRoot.Consumes);
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace Swagger.ObjectModel.Tests.Builders
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().ProduceMimeType(mimeType).Build();
 
-            Assert.True(swaggerRoot.Produces.Contains(mimeType));
+            Assert.Contains(mimeType, swaggerRoot.Produces);
         }
 
         [Fact]
@@ -181,17 +181,17 @@ namespace Swagger.ObjectModel.Tests.Builders
         [Fact]
         public void Should_AbleToSetParameter()
         {
-            var parameter = new Parameter() { Name="para" , In = ParameterIn.Query };
+            var parameter = new Parameter() { Name = "para", In = ParameterIn.Query };
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().Parameter(parameter).Build();
 
-            Assert.True(swaggerRoot.Parameters.ContainsKey(parameter.Name));            
+            Assert.True(swaggerRoot.Parameters.ContainsKey(parameter.Name));
         }
 
         [Fact]
         public void Should_AbleToSetParameterWithBuilder()
         {
-           var parameter = new ParameterBuilder().Name("para").In(ParameterIn.Query); 
+            var parameter = new ParameterBuilder().Name("para").In(ParameterIn.Query);
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().Parameter(parameter).Build();
 
@@ -213,10 +213,10 @@ namespace Swagger.ObjectModel.Tests.Builders
         {
             var response = new Response() { Description = "desc" };
 
-            var swaggerRoot = GetBasicSwaggerRootBuilder().Response("name",response).Build();
+            var swaggerRoot = GetBasicSwaggerRootBuilder().Response("name", response).Build();
 
             Assert.True(swaggerRoot.Responses.ContainsKey("name"));
-            Assert.Equal(response,swaggerRoot.Responses["name"]);
+            Assert.Equal(response, swaggerRoot.Responses["name"]);
         }
 
         [Fact]
@@ -235,7 +235,7 @@ namespace Swagger.ObjectModel.Tests.Builders
         {
             var securityScheme = new SecurityScheme();
 
-            var swaggerRoot = GetBasicSwaggerRootBuilder().SecurityDefinition("name",securityScheme).Build();
+            var swaggerRoot = GetBasicSwaggerRootBuilder().SecurityDefinition("name", securityScheme).Build();
 
             Assert.True(swaggerRoot.SecurityDefinitions.ContainsKey("name"));
             Assert.Equal(securityScheme, swaggerRoot.SecurityDefinitions["name"]);
@@ -254,7 +254,7 @@ namespace Swagger.ObjectModel.Tests.Builders
 
         [Fact]
         public void Should_AbleToSetSecurityRequirement()
-        {            
+        {
             var swaggerRoot = GetBasicSwaggerRootBuilder().SecurityRequirement(SecuritySchemes.ApiKey).Build();
 
             Assert.True(swaggerRoot.Security.ContainsKey(SecuritySchemes.ApiKey));
@@ -267,8 +267,8 @@ namespace Swagger.ObjectModel.Tests.Builders
             var externalDocumentation = new ExternalDocumentation() { Url = "url" };
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().ExternalDocumentation(externalDocumentation).Build();
-            
-            Assert.Equal(externalDocumentation , swaggerRoot.ExternalDocumentation);
+
+            Assert.Equal(externalDocumentation, swaggerRoot.ExternalDocumentation);
         }
 
         [Fact]
@@ -284,11 +284,11 @@ namespace Swagger.ObjectModel.Tests.Builders
         [Fact]
         public void Should_AbleToSetTag()
         {
-            var tag = new Tag() { Name="name" };
+            var tag = new Tag() { Name = "name" };
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().Tag(tag).Build();
 
-            Assert.True(swaggerRoot.Tags.Contains(tag));
+            Assert.Contains(tag, swaggerRoot.Tags);
         }
 
         [Fact]
@@ -298,7 +298,7 @@ namespace Swagger.ObjectModel.Tests.Builders
 
             var swaggerRoot = GetBasicSwaggerRootBuilder().Tag(tag).Build();
 
-            Assert.Equal(tag.Build().Name,swaggerRoot.Tags.FirstOrDefault().Name);            
+            Assert.Equal(tag.Build().Name, swaggerRoot.Tags.FirstOrDefault().Name);
         }
 
         [Fact]
@@ -322,6 +322,5 @@ namespace Swagger.ObjectModel.Tests.Builders
 
             Assert.Equal(schema.Build(), swaggerRoot.Definitions[name]);
         }
-
     }
 }

--- a/test/Swagger.ObjectModel.Tests/Builders/TagBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/TagBuilderTest.cs
@@ -17,20 +17,19 @@ namespace Swagger.ObjectModel.Tests.Builders
         [Fact]
         public void Should_ThrowRequiredFieldException_When_NameIsNotSet()
         {
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Build());            
+            Assert.Throws<RequiredFieldException>(() => builder.Build());
         }
-
 
         [Fact]
         public void Should_ThrowRequiredFieldException_When_NameIsNullOrWhiteSpace()
         {
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Name(null).Build());
-            Assert.Throws(typeof(RequiredFieldException), () => builder.Name("").Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Name(null).Build());
+            Assert.Throws<RequiredFieldException>(() => builder.Name("").Build());
         }
 
         [Fact]
         public void Should_AbleToSetName()
-        {            
+        {
             var tag = builder.Name(name).Build();
 
             Assert.Equal(name, tag.Name);
@@ -49,19 +48,19 @@ namespace Swagger.ObjectModel.Tests.Builders
         [Fact]
         public void Should_AbleToSetExternalDocumentation()
         {
-            var externalDocumentation = new ExternalDocumentation();        
+            var externalDocumentation = new ExternalDocumentation();
 
             var tag = builder.Name(name)
                              .ExternalDocumentation(externalDocumentation)
                              .Build();
-            
-            Assert.Equal(externalDocumentation, tag.ExternalDocumentation);            
+
+            Assert.Equal(externalDocumentation, tag.ExternalDocumentation);
         }
 
         [Fact]
         public void Should_AbleToSetExternalDocumentationWithBuilder()
         {
-            var exBuilder = new ExternalDocumentationBuilder().Url("url") ;
+            var exBuilder = new ExternalDocumentationBuilder().Url("url");
 
             var tag = builder.Name(name)
                              .ExternalDocumentation(exBuilder)


### PR DESCRIPTION
First of all , I feel so sorry for my mistakes on PR #140 . :pensive::pensive:

And here is somethings I have done for this PR

1. Fix xunit warnings after upgrading to version 2.3.0
2. ApiKeySecuritySchemeBuilder should return a new SecurityScheme object with Description
3. Add some new tests for Swagger.ObjectModel
