### PR TITLE
Implement RoutParam multi attribute usage #146

### DIFF
--- a/samples/Nancy.Swagger.Annotations.Demo/Modules/ServiceDetailsModule.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Modules/ServiceDetailsModule.cs
@@ -16,6 +16,7 @@ namespace Nancy.Swagger.Demo.Modules
         private const string ServiceTagName = "Service Details";
         private const string ServiceTagDescription = "Operations for handling the service";
 
+
         public ServiceDetailsModule(ISwaggerModelCatalog modelCatalog, ISwaggerTagCatalog tagCatalog) : base("/service")
         {
             modelCatalog.AddModel<ServiceOwner>();
@@ -32,12 +33,20 @@ namespace Nancy.Swagger.Demo.Modules
 
             Get("/customers", _ => GetServiceCustomers(), null, "GetCustomers");
 
+            //shows massaging multiple query params into single handler parameter.
+            Get("/customerspaged", _ => GetServiceCustomersPaged(GetRequestPaging()), null, "GetCustomersPaged");
+
             Get("/customers/{name}", parameters => GetServiceCustomer(parameters.name), null, "GetCustomer");
 
             Post("/customer/{service}", parameters => PostServiceCustomer(parameters.service, this.Bind<ServiceCustomer>()), null, "PostNewCustomer");
             
             Post("/customer/{name}/file", parameters => PostCustomerReview(parameters.name, null), null, "PostCustomerReview");
-            
+               
+        }
+
+        private object GetRequestPaging()
+        {
+            return new object(); //faking it, we would retun an object which reflects skip & take query params.
         }
 
 
@@ -88,6 +97,22 @@ namespace Nancy.Swagger.Demo.Modules
                 new ServiceCustomer() {CustomerName = "Jill"}
             };
         }
+
+        //Shows multiple attribute usage on handler parameter
+        [Route("GetCustomersPaged")]
+        [Route(HttpMethod.Get, "/customerspaged")]
+        [Route(Summary = "Get Service Customers")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(IEnumerable<ServiceCustomer>))]
+        [Route(Tags = new[] { ServiceTagName })]
+        private ServiceCustomer[] GetServiceCustomersPaged([RouteParam(ParameterIn.Query, Name ="Skip", DefaultValue = "0")] [RouteParam(ParameterIn.Query, Name = "Take", DefaultValue = "10")] object paging)
+        {
+            return new[]
+            {
+                new ServiceCustomer() {CustomerName = "Jack"},
+                new ServiceCustomer() {CustomerName = "Jill"}
+            };
+        }
+
 
         [Route("GetCustomer")]
         [Route(HttpMethod.Get, "/customers/{name}")]

--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
@@ -48,10 +48,6 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
 
             Parameters = CreateSwaggerParameters(infos);
 
-            //Parameters = handler.GetParameters().Where(x => x.GetCustomAttributes<RouteParamAttribute>().Any())
-            //    .Select(CreateSwaggerParameterData)
-            //    .ToList();
-
         }
 
         private IEnumerable<Parameter> CreateSwaggerParameters(IEnumerable<ParameterInfo> infos)
@@ -67,8 +63,8 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
                     result.Add(new AnnotatedBodyParameter(info, _modelCatalog));
                     continue;
                 }
-                var nonBodyAttrs = paramAttrs.Where(x => x.ParamIn != ParameterIn.Body);
 
+                var nonBodyAttrs = paramAttrs.Where(x => x.ParamIn != ParameterIn.Body);
                 foreach (var attr in nonBodyAttrs)
                 {
                     result.Add(new AnnotatedParameter(info, attr));

--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedParameter.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedParameter.cs
@@ -10,28 +10,13 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
 {
     public class AnnotatedParameter : Parameter
     {
-        public AnnotatedParameter(ParameterInfo pi)
+        public AnnotatedParameter(ParameterInfo pi, RouteParamAttribute attr)
         {
-            Name = pi.Name;
-
-            var paramAttrs = pi.GetCustomAttributes<RouteParamAttribute>();
-            if (!paramAttrs.Any())
-            {
-                Description = "Warning: no annotation found for this parameter";
-                In = ParameterIn.Query; // Required, so use query as fallback
-
-                return;
-            }
-
-            foreach (var attr in paramAttrs)
-            {
-                Name = attr.Name ?? Name;
-                In = attr.GetNullableParamType() ?? In;
-                Required = attr.GetNullableRequired() ?? Required;
-                Description = attr.Description ?? Description;
-                Default = attr.DefaultValue ?? Default;
-            }
-
+            Name = attr.Name ?? pi.Name;
+            In = attr.GetNullableParamType() ?? In;
+            Required = attr.GetNullableRequired() ?? Required;
+            Description = attr.Description ?? Description;
+            Default = attr.DefaultValue ?? Default;
             Type = Primitive.IsPrimitive(pi.ParameterType) ? Primitive.FromType(pi.ParameterType).Type : "string";
         }
     }


### PR DESCRIPTION
Allows handler parameters to have multiple RouteParam attributes, which is needed when multiple parameters are massaged into a single object. In my example, skip & take query parameters are used to create a Paging object. 
  