### PR TITLE
Added ModelAttribute.ShowReadOnlyProps

### DIFF
--- a/samples/Nancy.Swagger.Annotations.Demo/Models/Widget.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Models/Widget.cs
@@ -1,0 +1,27 @@
+﻿using Nancy.Swagger.Annotations.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nancy.Swagger.Demo.Models
+{
+    /// <summary>
+    /// Show the use of ShowReadOnlyProps to expose properties without a public setter.
+    /// </summary>
+    [Model("Widget", Description = "A Thing that does something", ShowReadOnlyProps = true)]
+    public class Widget
+    {
+        public Widget(string name, double price)
+        {
+            Name = name;
+            Price = price;
+        }
+
+        [ModelProperty(Description = "The Name of the Widget")]
+        public string Name { get; protected set; }
+
+        [ModelProperty(Description = "The Price of the Widget")]
+        public double Price { get; protected set; }
+    }
+}

--- a/samples/Nancy.Swagger.Annotations.Demo/Modules/ServiceDetailsModule.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Modules/ServiceDetailsModule.cs
@@ -15,10 +15,12 @@ namespace Nancy.Swagger.Demo.Modules
     {
         private const string ServiceTagName = "Service Details";
         private const string ServiceTagDescription = "Operations for handling the service";
+        private const string WidgetsTagName = "Available Widgets";
 
         public ServiceDetailsModule(ISwaggerModelCatalog modelCatalog, ISwaggerTagCatalog tagCatalog) : base("/service")
         {
             modelCatalog.AddModel<ServiceOwner>();
+            modelCatalog.AddModel<Widget>();
 
             tagCatalog.AddTag(new Tag()
             {
@@ -29,6 +31,8 @@ namespace Nancy.Swagger.Demo.Modules
             Get("/", _ => GetHome(), null, "ServiceHome");
 
             Get("/details", _ => GetServiceDetails(), null, "GetDetails");
+
+            Get("/widgets", _ => GetWidgets(), null, "GetWidgets");
 
             Get("/customers", _ => GetServiceCustomers(), null, "GetCustomers");
 
@@ -74,7 +78,22 @@ namespace Nancy.Swagger.Demo.Modules
                 }
             };
         }
-        
+
+        [Route("GetWidgets")]
+        [Route(HttpMethod.Get, "/widgets")]
+        [Route(Summary = "Get List of Widgets available")]
+        [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(List<Widget>))]
+        [Route(Tags = new[] { WidgetsTagName })]
+        private List<Widget> GetWidgets()
+        {
+            return new List<Widget>()
+            {
+                new Widget("FooWidget", 1.23),
+                new Widget("BarWidget", 4.56)
+            };
+        }
+
+
         [Route("GetCustomers")]
         [Route(HttpMethod.Get, "/customers")]
         [Route(Summary = "Get Service Customers")]

--- a/src/Nancy.Swagger.Annotations/Attributes/ModelAttribute.cs
+++ b/src/Nancy.Swagger.Annotations/Attributes/ModelAttribute.cs
@@ -11,5 +11,11 @@ namespace Nancy.Swagger.Annotations.Attributes
         }
 
         public string Description { get; set; }
+
+        /// <summary>
+        /// By default, only read/write props are shown, this 
+        /// prop allows read only props to be shown.
+        /// </summary>
+        public bool ShowReadOnlyProps { get; set; }
     }
 }

--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedModel.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedModel.cs
@@ -12,8 +12,10 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
         public AnnotatedModel(Type type, ModelAttribute modelAttr) : base(type)
         {
             // Only use properties which have a public getter and setter
+            // If the ModelAttribute has ShowReadOnlyProps the the prop just needs
+            // a public getter.
             var typeProperties = type.GetProperties()
-                                        .Where(pi => pi.CanWrite && pi.GetSetMethod(true).IsPublic)
+                                        .Where(pi => modelAttr.ShowReadOnlyProps || ( pi.CanWrite && pi.GetSetMethod(true).IsPublic) )
                                         .Where(pi => pi.CanRead && pi.GetGetMethod(true).IsPublic);
 
             Properties = typeProperties.Select(CreateSwaggerModelPropertyData).ToList();


### PR DESCRIPTION
By default, only properties with public getters and setters are exposed, this option allows read only public properties to be shown in swagger. 