### PR TITLE
Allow RouteParamAttribute on method

### DIFF
--- a/src/Nancy.Swagger.Annotations/Attributes/RouteParamAttribute.cs
+++ b/src/Nancy.Swagger.Annotations/Attributes/RouteParamAttribute.cs
@@ -3,7 +3,7 @@ using Swagger.ObjectModel;
 
 namespace Nancy.Swagger.Annotations.Attributes
 {
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = true, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter, Inherited = true, AllowMultiple = true)]
     public class RouteParamAttribute : SwaggerDataTypeAttribute
     {
         private ParameterIn? paramIn;
@@ -17,6 +17,7 @@ namespace Nancy.Swagger.Annotations.Attributes
             : base(name)
         {
             this.ParamIn = paramIn;
+            this.ParamType = typeof(string);
         }
 
         public ParameterIn ParamIn
@@ -29,5 +30,7 @@ namespace Nancy.Swagger.Annotations.Attributes
         {
             return this.paramIn;
         }
+
+        public Type ParamType { get; set; }
     }
 }

--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedBodyParameter.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedBodyParameter.cs
@@ -3,16 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Nancy.Swagger.Annotations.Attributes;
 using Swagger.ObjectModel;
 
 namespace Nancy.Swagger.Annotations.SwaggerObjects
 {
     public class AnnotatedBodyParameter : BodyParameter
     {
-        public AnnotatedBodyParameter(ParameterInfo pi, ISwaggerModelCatalog modelCatalog)
+        public AnnotatedBodyParameter(string name, Type paramType, RouteParamAttribute attrib, ISwaggerModelCatalog modelCatalog)
         {
-            Name = pi.Name;
-            this.AddBodySchema(pi.ParameterType, modelCatalog);
+            Name = attrib.Name ?? name;
+            this.AddBodySchema(paramType, modelCatalog);
         }
     }
 }

--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
@@ -71,6 +71,7 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
                     }
 
                     paramsList.Add(new AnnotatedBodyParameter(attrib.Name, attrib.ParamType, attrib, _modelCatalog));
+                    continue;
                 }
                 if (paramsList.Any(x => x.Name.Equals(attrib.Name)))
                 {

--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
@@ -57,7 +57,7 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
             foreach (var attrib in routeParamsAttributes)
             {
                 if (string.IsNullOrEmpty(attrib.Name))
-                    throw new ArgumentNullException("Name", "RouteParam name cannot be null when used on method.");
+                    throw new ArgumentNullException("Name", "RouteParamAttribute name cannot be null when used on method.");
                 if (attrib.ParamIn == ParameterIn.Body)
                 {
                     if (paramsList.Where(x => x.GetType() == typeof(AnnotatedBodyParameter)).Any())
@@ -67,7 +67,7 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
 
                     if (attrib.ParamType == null)
                     {
-                        throw new ArgumentNullException("ParamType", "ParamType for Body must be specified when RouteParam used on method.");
+                        throw new ArgumentNullException("ParamType", "ParamType for Body must be specified when RouteParamAttribute used on method.");
                     }
 
                     paramsList.Add(new AnnotatedBodyParameter(attrib.Name, attrib.ParamType, attrib, _modelCatalog));

--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedParameter.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedParameter.cs
@@ -10,14 +10,14 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
 {
     public class AnnotatedParameter : Parameter
     {
-        public AnnotatedParameter(ParameterInfo pi, RouteParamAttribute attr)
+        public AnnotatedParameter(string name, Type paramType, RouteParamAttribute attr)
         {
-            Name = attr.Name ?? pi.Name;
+            Name = attr.Name ?? name;
             In = attr.GetNullableParamType() ?? In;
             Required = attr.GetNullableRequired() ?? Required;
             Description = attr.Description ?? Description;
             Default = attr.DefaultValue ?? Default;
-            Type = Primitive.IsPrimitive(pi.ParameterType) ? Primitive.FromType(pi.ParameterType).Type : "string";
+            Type = Primitive.IsPrimitive(paramType) ? Primitive.FromType(paramType).Type : "string";
         }
     }
 }


### PR DESCRIPTION
This allows you to document parameters even when there are no parameters at all on the handler method at all.  This is needed when using only query parameters, since they don't appear on the args object you would typically extract them from the Request object inside your handler method. 

This change also allows RouteParamAttribute descendants to be used - passing true to GetCustomAttributes - should not have any negative impact. 

Introduces RouteParamAttribute.ParamType property to allow overrideing the param type.