### PR TITLE
fix format specification

### DIFF
--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedParameter.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedParameter.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
 using Nancy.Swagger.Annotations.Attributes;
 using Swagger.ObjectModel;
 
@@ -17,7 +13,15 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
             Required = attr.GetNullableRequired() ?? Required;
             Description = attr.Description ?? Description;
             Default = attr.DefaultValue ?? Default;
-            Type = Primitive.IsPrimitive(paramType) ? Primitive.FromType(paramType).Type : "string";
+            if (Primitive.IsPrimitive(paramType))
+            {
+                Type = Primitive.FromType(paramType).Type;
+                Format = Primitive.FromType(paramType).Format;
+            }
+            else
+            {
+                Type = "string";
+            }
         }
     }
 }

--- a/src/Nancy.Swagger/SwaggerExtensions.cs
+++ b/src/Nancy.Swagger/SwaggerExtensions.cs
@@ -45,6 +45,10 @@ namespace Nancy.Swagger
                 return dataType;
             }
 
+            if (type.IsNullable())
+            {
+                type = Nullable.GetUnderlyingType(type);
+            }
             if (Primitive.IsPrimitive(type))
             {
                 var primitive = Primitive.FromType(type);
@@ -54,10 +58,7 @@ namespace Nancy.Swagger
 
                 return dataType;
             }
-            if (type.IsNullable())
-            {
-                type = Nullable.GetUnderlyingType(type);
-            }
+ 
 
             if (type.IsContainer())
             {

--- a/src/Nancy.Swagger/SwaggerSchemaFactory.cs
+++ b/src/Nancy.Swagger/SwaggerSchemaFactory.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Swagger.ObjectModel;
 
 namespace Nancy.Swagger
@@ -96,6 +95,7 @@ namespace Nancy.Swagger
         {
             Schema schema = new Schema();
             schema.Type = property.Type?.ToCamelCase();
+            schema.Format = property.Format?.ToCamelCase();
             schema.Description = property.Description;
 
             if (schema.Type == null)

--- a/test/Nancy.Swagger.Tests/SwaggerExtensionsTests.cs
+++ b/test/Nancy.Swagger.Tests/SwaggerExtensionsTests.cs
@@ -37,6 +37,32 @@ namespace Nancy.Swagger.Tests
         }
 
         [Fact]
+        public void ToModelProperty_Primitive_ShouldHaveFormatSet()
+        {
+            new SwaggerModelPropertyData { Type = typeof(long) }
+                .ToModelProperty()
+                .ShouldEqual(
+                    new ModelProperty
+                    {
+                        Type = "integer",
+                        Format = "int64"
+                    });
+        }
+
+        [Fact]
+        public void ToModelProperty_NullablePrimitive_ShouldHaveFormatSet()
+        {
+            new SwaggerModelPropertyData { Type = typeof(long?) }
+                .ToModelProperty()
+                .ShouldEqual(
+                    new ModelProperty
+                    {
+                        Type = "integer",
+                        Format = "int64"
+                    });
+        }
+
+        [Fact]
         public void ToModelProperty_PrimitiveCollection_ShouldHaveTypeArrayAndItemsTypeSet()
         {
             new SwaggerModelPropertyData

--- a/test/Nancy.Swagger.Tests/SwaggerSchemaFactoryTests.cs
+++ b/test/Nancy.Swagger.Tests/SwaggerSchemaFactoryTests.cs
@@ -45,7 +45,7 @@ namespace Nancy.Swagger.Tests
 
         [Fact]
         public void EnumType_WithDefinition_ShouldCreateEnumSchema()
-        {            
+        {
             var description = "Sample description";
             var model = new Model { Description = description };
             var enumType = typeof(HttpStatusCode);
@@ -60,7 +60,7 @@ namespace Nancy.Swagger.Tests
 
         [Fact]
         public void EnumType_WithoutDefinition_ShouldCreateEnumSchema()
-        {            
+        {
             var model = new Model();
             var enumType = typeof(HttpStatusCode);
 
@@ -70,7 +70,7 @@ namespace Nancy.Swagger.Tests
 
         [Fact]
         public void NullableEnumType_WithDefinition_ShouldCreateEnumSchema()
-        {            
+        {
             var description = "Sample description";
             var model = new Model { Description = description };
             var enumType = typeof(HttpStatusCode);
@@ -85,7 +85,7 @@ namespace Nancy.Swagger.Tests
 
         [Fact]
         public void NullableEnumType_WithoutDefinition_ShouldCreateEnumSchema()
-        {            
+        {
             var model = new Model();
             var enumType = typeof(HttpStatusCode);
 
@@ -95,9 +95,10 @@ namespace Nancy.Swagger.Tests
 
         [Fact]
         public void ObjectType_WithDefinition_ShouldCreateObjectSchema()
-        {            
+        {
             var description = "Sample description";
-            var model = new Model {
+            var model = new Model
+            {
                 Description = description,
                 Properties = new Dictionary<string, ModelProperty>()
             };
@@ -111,8 +112,38 @@ namespace Nancy.Swagger.Tests
         }
 
         [Fact]
+        public void ObjectType_WithDefinition_ShouldCreateObjectSchema_WithPropertiesTypeAndFormat()
+        {
+            var description = "Sample description";
+            var model = new Model
+            {
+                Description = description,
+                Properties = new Dictionary<string, ModelProperty>
+                {
+                    {  "longInt", new ModelProperty { Type = "integer", Format = "int64" }},
+                    {  "decimalNumber", new ModelProperty { Type = "number", Format = "decimal" }}
+                }
+            };
+
+
+            var schema = model.CreateSchema(typeof(Schema), true);
+            Assert.Equal("object", schema.Type);
+            Assert.Equal(description, schema.Description);
+            Assert.Null(schema.Required);
+            Assert.NotEmpty(schema.Properties);
+            Assert.Null(schema.Ref);
+
+            foreach (var modelProperty in model.Properties)
+            {
+                Assert.Contains(modelProperty.Key, schema.Properties.Keys);
+                Assert.Equal(modelProperty.Value.Type, schema.Properties[modelProperty.Key].Type);
+                Assert.Equal(modelProperty.Value.Format, schema.Properties[modelProperty.Key].Format);
+            }
+        }
+
+        [Fact]
         public void ObjectType_WithoutDefinition_ShouldCreateObjectSchema()
-        {            
+        {
             var model = new Model();
 
             var schema = model.CreateSchema(typeof(Schema), false);

--- a/test/Nancy.Swagger.Tests/SwaggerTypeMappingTests.cs
+++ b/test/Nancy.Swagger.Tests/SwaggerTypeMappingTests.cs
@@ -1,21 +1,26 @@
-using Should;
 using Xunit;
 
 namespace Nancy.Swagger.Tests
 {
     public class SwaggerTypeMappingTests
     {
+        class OriginalType { }
+
+        class AnotherOriginalType { }
+
+        class MappedType { }
+
         [Fact]
         public void ShouldAdd_AndGet_TypeMappings()
         {
             SwaggerTypeMapping.ResetMappedTypes();
 
-            Assert.False(SwaggerTypeMapping.IsMappedType(typeof(long)));
+            Assert.False(SwaggerTypeMapping.IsMappedType(typeof(OriginalType)));
 
-            SwaggerTypeMapping.AddTypeMapping(typeof(long), typeof(double));
+            SwaggerTypeMapping.AddTypeMapping(typeof(OriginalType), typeof(MappedType));
 
-            Assert.True(SwaggerTypeMapping.IsMappedType(typeof(long)));
-            Assert.Equal(typeof(double), SwaggerTypeMapping.GetMappedType(typeof(long)));
+            Assert.True(SwaggerTypeMapping.IsMappedType(typeof(OriginalType)));
+            Assert.Equal(typeof(MappedType), SwaggerTypeMapping.GetMappedType(typeof(OriginalType)));
         }
 
         [Fact]
@@ -23,15 +28,15 @@ namespace Nancy.Swagger.Tests
         {
             SwaggerTypeMapping.ResetMappedTypes();
 
-            Assert.False(SwaggerTypeMapping.IsMappedType(typeof(long)));
+            Assert.False(SwaggerTypeMapping.IsMappedType(typeof(OriginalType)));
 
-            SwaggerTypeMapping.AddTypeMapping(typeof(int), typeof(long));
-            SwaggerTypeMapping.AddTypeMapping(typeof(long), typeof(double));
+            SwaggerTypeMapping.AddTypeMapping(typeof(AnotherOriginalType), typeof(OriginalType));
+            SwaggerTypeMapping.AddTypeMapping(typeof(OriginalType), typeof(MappedType));
 
-            Assert.True(SwaggerTypeMapping.IsMappedType(typeof(int)));
-            Assert.True(SwaggerTypeMapping.IsMappedType(typeof(long)));
+            Assert.True(SwaggerTypeMapping.IsMappedType(typeof(AnotherOriginalType)));
+            Assert.True(SwaggerTypeMapping.IsMappedType(typeof(OriginalType)));
 
-            Assert.Equal(typeof(double), SwaggerTypeMapping.GetMappedType(typeof(int)));
+            Assert.Equal(typeof(MappedType), SwaggerTypeMapping.GetMappedType(typeof(AnotherOriginalType)));
         }
     }
 }

--- a/test/Nancy.Swagger.Tests/TestModel.cs
+++ b/test/Nancy.Swagger.Tests/TestModel.cs
@@ -3,5 +3,9 @@
     public class TestModel
     {
         public int SomeInt { get; set; }
+
+        public long SomeLong { get; set; }
+
+        public long? SomeNullableLong { get; set; }
     }
 }


### PR DESCRIPTION
Hi, i've fixed some issues with type fromat specification in query parameters and models. So with this fixes types like int64 and decimal correctly passes to swagger schema.