### PR TITLE
ExternalDocumentation now correctly inherits from SwaggerModel

### DIFF
--- a/samples/Nancy.Swagger.Demo/TagProviders/UserTagProvider.cs
+++ b/samples/Nancy.Swagger.Demo/TagProviders/UserTagProvider.cs
@@ -4,8 +4,6 @@ using Nancy.Swagger.Services;
 
 namespace Nancy.Swagger.Demo.TagProviders
 {
-
-
     public class UserTagProvider : ISwaggerTagProvider
     {
         public Tag GetTag()
@@ -13,7 +11,8 @@ namespace Nancy.Swagger.Demo.TagProviders
             return new Tag()
             {
                 Description = "Operations related to users",
-                Name = "Users"
+                Name = "Users",
+                ExternalDocumentation = new ExternalDocumentation() {Description = "Check our documentation", Url = "http://nancyfx.org/"}
             };
         }
     }

--- a/src/Swagger.ObjectModel/ExternalDocumentation.cs
+++ b/src/Swagger.ObjectModel/ExternalDocumentation.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// The external documentation.
     /// </summary>
-    public class ExternalDocumentation
+    public class ExternalDocumentation : SwaggerModel
     {
         /// <summary>
         /// A short description of the target documentation. GFM syntax can be used for rich text representation.

--- a/test/Swagger.ObjectModel.Tests/Builders/ExternalDocumentationBuilderTest.cs
+++ b/test/Swagger.ObjectModel.Tests/Builders/ExternalDocumentationBuilderTest.cs
@@ -50,5 +50,15 @@ namespace Swagger.ObjectModel.Tests.Builders
             Assert.Equal(url, externalDocumentation.Url);
             Assert.Equal(description, externalDocumentation.Description);
         }
+
+        [Fact]
+        public void Should_AssignableFromSwaggerModel()
+        {         
+            var externalDocumentation = builder.Url(url)
+                                               .Build();
+
+            Assert.NotNull(externalDocumentation);
+            Assert.IsAssignableFrom<SwaggerModel>(externalDocumentation);
+        }
     }
 }


### PR DESCRIPTION
ExternalDocumentation now serialises correctly. Added an example into the demo.