### PR TITLE
Removes Parameter types from generated swagger path. #166

### DIFF
--- a/samples/Nancy.Swagger.Annotations.Demo/Bootstrapper.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Bootstrapper.cs
@@ -49,6 +49,8 @@ namespace Nancy.Swagger.Demo
         protected override void RequestStartup(TinyIoCContainer container, IPipelines pipelines, NancyContext context)
         {
             pipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Origin", "*"));
+            pipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Headers", "*"));
+            pipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Methods", "*"));
         }
     }
 }

--- a/samples/Nancy.Swagger.Annotations.Demo/Modules/ServiceDetailsModule.cs
+++ b/samples/Nancy.Swagger.Annotations.Demo/Modules/ServiceDetailsModule.cs
@@ -42,7 +42,7 @@ namespace Nancy.Swagger.Demo.Modules
 
             Get("/customers/{name}", parameters => GetServiceCustomer(parameters.name), null, "GetCustomer");
 
-            Post("/customer/{service}", parameters => PostServiceCustomer(parameters.service, this.Bind<ServiceCustomer>()), null, "PostNewCustomer");
+            Post("/customer/{serviceGuid:guid}", parameters => PostServiceCustomer(parameters.serviceGuid, this.Bind<ServiceCustomer>()), null, "PostNewCustomer");
             
             Post("/customer/{name}/file", parameters => PostCustomerReview(parameters.name, null), null, "PostCustomerReview");
                
@@ -144,14 +144,13 @@ namespace Nancy.Swagger.Demo.Modules
         }
 
         [Route("PostNewCustomer")]
-        [Route(HttpMethod.Post, "/customer/{service}")]
         [Route(Summary = "Post Service Customer")]
         [SwaggerResponse(HttpStatusCode.OK, Message = "OK", Model = typeof(ServiceCustomer))]
         [Route(Produces = new[] { "application/json" })]
         [Route(Consumes = new[] { "application/json", "application/xml" })]
         [Route(Tags = new[] { ServiceTagName })]
         private ServiceCustomer PostServiceCustomer(
-            [RouteParam(ParameterIn.Path, DefaultValue = "my-service")] string service, 
+            [RouteParam(ParameterIn.Path, Description = "The GUID that identifies the service")] string serviceGuid, 
             [RouteParam(ParameterIn.Body)] ServiceCustomer customer)
         {
             return customer;

--- a/samples/Nancy.Swagger.Autofac.Demo/AutofacBootstrapper.cs
+++ b/samples/Nancy.Swagger.Autofac.Demo/AutofacBootstrapper.cs
@@ -28,6 +28,8 @@ namespace Nancy.Swagger.Autofac.Demo
 
             SwaggerAnnotationsConfig.ShowOnlyAnnotatedRoutes = true;
             this.ApplicationPipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Origin", "*"));
+            this.ApplicationPipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Headers", "*"));
+            this.ApplicationPipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Methods", "*"));
         }
     }
 }

--- a/samples/Nancy.Swagger.Demo/Bootstrapper.cs
+++ b/samples/Nancy.Swagger.Demo/Bootstrapper.cs
@@ -38,6 +38,8 @@ namespace Nancy.Swagger.Demo
         protected override void RequestStartup(TinyIoCContainer container, IPipelines pipelines, NancyContext context)
         {
             pipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Origin", "*"));
+            pipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Headers", "*"));
+            pipelines.AfterRequest.AddItemToEndOfPipeline(x => x.Response.Headers.Add("Access-Control-Allow-Methods", "*"));
         }
     }
 }

--- a/src/Nancy.Swagger/Services/SwaggerRouteData.cs
+++ b/src/Nancy.Swagger/Services/SwaggerRouteData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Swagger.ObjectModel;
+using System.Text.RegularExpressions;
 
 namespace Nancy.Swagger.Services
 {
@@ -8,7 +9,7 @@ namespace Nancy.Swagger.Services
     {
         public SwaggerRouteData(string path, PathItem pathItem)
         {
-            Path = path;
+            Path = RemovePathParameterTypes(path);
             PathItem = pathItem;
             Types = new Dictionary<HttpMethod, Type>();
         }
@@ -29,6 +30,17 @@ namespace Nancy.Swagger.Services
                 combined.Types.Add(kvp.Key, kvp.Value);
             }
             return combined;
+        }
+
+        /// <summary>
+        /// Removes parameter types from Nancy routes - Swagger doesn't expect them.
+        /// Examples: "/service/customers/{name:guid}" becomes "/service/customers/{name}"
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        private string RemovePathParameterTypes(string path)
+        {
+            return Regex.Replace(path, @":\w+}", "}");
         }
     }
 }


### PR DESCRIPTION
#166 

This will remove the path parameter type from the swagger, as it will not work. 
For example, "/service/customers/{name:guid}" becomes "/service/customers/{name}"

Also added CORS stuff, because the examples weren't working for POSTs. 
And boy, the Endpoints I created two years ago aren't very RESTFUL. :P