### PR TITLE
Report which annotated operation contains a duplicate status

### DIFF
--- a/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
+++ b/src/Nancy.Swagger.Annotations/SwaggerObjects/AnnotatedOperation.cs
@@ -40,10 +40,17 @@ namespace Nancy.Swagger.Annotations.SwaggerObjects
                 Tags = attr.Tags ?? Tags;
             }
 
-            Responses = handler.GetCustomAttributes<SwaggerResponseAttribute>()
-                .Select(CreateSwaggerResponseObject)
-                .ToDictionary(x => x.GetStatusCode().ToString(), y => (global::Swagger.ObjectModel.Response) y);
-
+            try
+            {
+                Responses = handler.GetCustomAttributes<SwaggerResponseAttribute>()
+                    .Select(CreateSwaggerResponseObject)
+                    .ToDictionary(x => x.GetStatusCode().ToString(), y => (global::Swagger.ObjectModel.Response)y);
+            }
+            catch (ArgumentException e) when (e.Message == "An item with the same key has already been added.")
+            {
+                throw new Exception($"Duplicated status code found at operation {name}");
+            }
+            
             var paramsList = new List<Parameter>();
             CreateSwaggerParametersFromMethodAttributes(handler, paramsList);
             CreateSwaggerParametersFromParameters(handler, paramsList);


### PR DESCRIPTION
The current exception makes it very hard to find which annotated method contains a duplicate (by status code) annotation.